### PR TITLE
support filtering plugins

### DIFF
--- a/internal/store/plugin.go
+++ b/internal/store/plugin.go
@@ -1,26 +1,60 @@
 package store
 
 import (
+	"strings"
+
 	"github.com/mattermost/mattermost-marketplace/internal/model"
 )
 
+func pluginMatchesFilter(plugin *model.Plugin, filter string) bool {
+	filter = strings.ToLower(filter)
+	if strings.ToLower(plugin.Manifest.Id) == filter {
+		return true
+	}
+
+	if strings.Contains(strings.ToLower(plugin.Manifest.Name), filter) {
+		return true
+	}
+
+	if strings.Contains(strings.ToLower(plugin.Manifest.Description), filter) {
+		return true
+	}
+
+	return false
+}
+
 // GetPlugins fetches the given page of plugins. The first page is 0.
-func (store *Store) GetPlugins(filter *model.PluginFilter) ([]*model.Plugin, error) {
-	if len(store.plugins) == 0 || filter.PerPage == 0 {
-		return nil, nil
-	}
-	if filter.PerPage == model.AllPerPage {
-		return store.plugins, nil
+func (store *Store) GetPlugins(pluginFilter *model.PluginFilter) ([]*model.Plugin, error) {
+	var plugins []*model.Plugin
+
+	filter := strings.TrimSpace(pluginFilter.Filter)
+	if filter == "" {
+		plugins = store.plugins
+	} else {
+		for _, plugin := range store.plugins {
+			if !pluginMatchesFilter(plugin, filter) {
+				continue
+			}
+
+			plugins = append(plugins, plugin)
+		}
 	}
 
-	start := (filter.Page) * filter.PerPage
-	end := (filter.Page + 1) * filter.PerPage
-	if start >= len(store.plugins) {
+	if len(plugins) == 0 || pluginFilter.PerPage == 0 {
 		return nil, nil
 	}
-	if end > len(store.plugins) {
-		end = len(store.plugins)
+	if pluginFilter.PerPage == model.AllPerPage {
+		return plugins, nil
 	}
 
-	return store.plugins[start:end], nil
+	start := (pluginFilter.Page) * pluginFilter.PerPage
+	end := (pluginFilter.Page + 1) * pluginFilter.PerPage
+	if start >= len(plugins) {
+		return nil, nil
+	}
+	if end > len(plugins) {
+		end = len(plugins)
+	}
+
+	return plugins[start:end], nil
 }

--- a/internal/store/plugin.go
+++ b/internal/store/plugin.go
@@ -25,6 +25,10 @@ func pluginMatchesFilter(plugin *model.Plugin, filter string) bool {
 
 // GetPlugins fetches the given page of plugins. The first page is 0.
 func (store *Store) GetPlugins(pluginFilter *model.PluginFilter) ([]*model.Plugin, error) {
+	if pluginFilter.PerPage == 0 {
+		return nil, nil
+	}
+
 	var plugins []*model.Plugin
 
 	filter := strings.TrimSpace(pluginFilter.Filter)
@@ -40,7 +44,7 @@ func (store *Store) GetPlugins(pluginFilter *model.PluginFilter) ([]*model.Plugi
 		}
 	}
 
-	if len(plugins) == 0 || pluginFilter.PerPage == 0 {
+	if len(plugins) == 0 {
 		return nil, nil
 	}
 	if pluginFilter.PerPage == model.AllPerPage {

--- a/internal/store/plugin_test.go
+++ b/internal/store/plugin_test.go
@@ -118,7 +118,7 @@ func TestPlugins(t *testing.T) {
 		require.Equal(t, []*model.Plugin{demoPlugin}, actualPlugins)
 	})
 
-	t.Run("id match, case-insensitivei", func(t *testing.T) {
+	t.Run("id match, case-insensitive", func(t *testing.T) {
 		actualPlugins, err := sqlStore.GetPlugins(&model.PluginFilter{PerPage: model.AllPerPage,
 			Filter: "com.mattermost.demo-PLUGIN",
 		})

--- a/internal/store/plugin_test.go
+++ b/internal/store/plugin_test.go
@@ -12,23 +12,31 @@ import (
 )
 
 func TestPlugins(t *testing.T) {
-	plugin1 := &model.Plugin{
+	demoPlugin := &model.Plugin{
 		HomepageURL:       "https://github.com/mattermost/mattermost-plugin-demo",
 		DownloadURL:       "https://github.com/mattermost/mattermost-plugin-demo/releases/download/v0.1.0/com.mattermost.demo-plugin-0.1.0.tar.gz",
 		DownloadSignature: []byte("signature"),
-		Manifest:          &mattermostModel.Manifest{},
+		Manifest: &mattermostModel.Manifest{
+			Id:          "com.mattermost.demo-plugin",
+			Name:        "Demo Plugin",
+			Description: "This plugin demonstrates the capabilities of a Mattermost plugin.",
+		},
 	}
 
-	plugin2 := &model.Plugin{
+	starterPlugin := &model.Plugin{
 		HomepageURL:       "https://github.com/mattermost/mattermost-plugin-starter-template",
 		DownloadURL:       "https://github.com/mattermost/mattermost-plugin-starter-template/releases/download/v0.1.0/com.mattermost.plugin-starter-template-0.1.0.tar.gz",
 		DownloadSignature: []byte("signature2"),
-		Manifest:          &mattermostModel.Manifest{},
+		Manifest: &mattermostModel.Manifest{
+			Id:          "com.mattermost.plugin-starter-template",
+			Name:        "Plugin Starter Template",
+			Description: "This plugin serves as a starting point for writing a Mattermost plugin.",
+		},
 	}
 
 	data, err := json.Marshal([]*model.Plugin{
-		plugin1,
-		plugin2,
+		demoPlugin,
+		starterPlugin,
 	})
 	require.NoError(t, err)
 
@@ -53,7 +61,7 @@ func TestPlugins(t *testing.T) {
 			Filter:  "",
 		})
 		require.NoError(t, err)
-		require.Equal(t, []*model.Plugin{plugin1}, actualPlugins)
+		require.Equal(t, []*model.Plugin{demoPlugin}, actualPlugins)
 	})
 
 	t.Run("page 0, per page 10", func(t *testing.T) {
@@ -63,7 +71,7 @@ func TestPlugins(t *testing.T) {
 			Filter:  "",
 		})
 		require.NoError(t, err)
-		require.Equal(t, []*model.Plugin{plugin1, plugin2}, actualPlugins)
+		require.Equal(t, []*model.Plugin{demoPlugin, starterPlugin}, actualPlugins)
 	})
 
 	t.Run("page 0, per page 1", func(t *testing.T) {
@@ -73,7 +81,7 @@ func TestPlugins(t *testing.T) {
 			Filter:  "",
 		})
 		require.NoError(t, err)
-		require.Equal(t, []*model.Plugin{plugin1}, actualPlugins)
+		require.Equal(t, []*model.Plugin{demoPlugin}, actualPlugins)
 	})
 
 	t.Run("page 0, per page 10", func(t *testing.T) {
@@ -83,7 +91,7 @@ func TestPlugins(t *testing.T) {
 			Filter:  "",
 		})
 		require.NoError(t, err)
-		require.Equal(t, []*model.Plugin{plugin1, plugin2}, actualPlugins)
+		require.Equal(t, []*model.Plugin{demoPlugin, starterPlugin}, actualPlugins)
 	})
 
 	t.Run("default paging", func(t *testing.T) {
@@ -91,6 +99,70 @@ func TestPlugins(t *testing.T) {
 			Filter: "",
 		})
 		require.NoError(t, err)
-		require.Equal(t, []*model.Plugin{plugin1, plugin2}, actualPlugins)
+		require.Equal(t, []*model.Plugin{demoPlugin, starterPlugin}, actualPlugins)
+	})
+
+	t.Run("filter spaces", func(t *testing.T) {
+		actualPlugins, err := sqlStore.GetPlugins(&model.PluginFilter{PerPage: model.AllPerPage,
+			Filter: "  ",
+		})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Plugin{demoPlugin, starterPlugin}, actualPlugins)
+	})
+
+	t.Run("id match, exact", func(t *testing.T) {
+		actualPlugins, err := sqlStore.GetPlugins(&model.PluginFilter{PerPage: model.AllPerPage,
+			Filter: "com.mattermost.demo-plugin",
+		})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Plugin{demoPlugin}, actualPlugins)
+	})
+
+	t.Run("id match, case-insensitivei", func(t *testing.T) {
+		actualPlugins, err := sqlStore.GetPlugins(&model.PluginFilter{PerPage: model.AllPerPage,
+			Filter: "com.mattermost.demo-PLUGIN",
+		})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Plugin{demoPlugin}, actualPlugins)
+	})
+
+	t.Run("name match, exact", func(t *testing.T) {
+		actualPlugins, err := sqlStore.GetPlugins(&model.PluginFilter{PerPage: model.AllPerPage,
+			Filter: "Plugin Starter Template",
+		})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Plugin{starterPlugin}, actualPlugins)
+	})
+
+	t.Run("name match, partial", func(t *testing.T) {
+		actualPlugins, err := sqlStore.GetPlugins(&model.PluginFilter{PerPage: model.AllPerPage,
+			Filter: "Starter",
+		})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Plugin{starterPlugin}, actualPlugins)
+	})
+
+	t.Run("name match, case-insensitive", func(t *testing.T) {
+		actualPlugins, err := sqlStore.GetPlugins(&model.PluginFilter{PerPage: model.AllPerPage,
+			Filter: "TEMPLATE",
+		})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Plugin{starterPlugin}, actualPlugins)
+	})
+
+	t.Run("description match, partial", func(t *testing.T) {
+		actualPlugins, err := sqlStore.GetPlugins(&model.PluginFilter{PerPage: model.AllPerPage,
+			Filter: "capabilities",
+		})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Plugin{demoPlugin}, actualPlugins)
+	})
+
+	t.Run("description match, case-insensitive, multiple matches", func(t *testing.T) {
+		actualPlugins, err := sqlStore.GetPlugins(&model.PluginFilter{PerPage: model.AllPerPage,
+			Filter: "MATTERMOST",
+		})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Plugin{demoPlugin, starterPlugin}, actualPlugins)
 	})
 }


### PR DESCRIPTION
Very rudimentary support for filtering plugins via the `filter` query string parameter.

Note that paging already existed. We'll defer worrying about the Mattermost server version for now.

https://mattermost.atlassian.net/browse/MM-17544