### PR TITLE
Fix default invocation

### DIFF
--- a/cmd/marketplace/main.go
+++ b/cmd/marketplace/main.go
@@ -10,9 +10,6 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "marketplace",
 	Short: "Marketplace is a repository of Mattermost plugins.",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return serverCmd.RunE(cmd, args)
-	},
 	// SilenceErrors allows us to explicitly log the error returned from rootCmd below.
 	SilenceErrors: true,
 }


### PR DESCRIPTION
Remove the `RunE` declaration for the root command so that invoking without the `server` subcommand just displays the help. At the moment, there is only the single subcommand, but in the future this will likely include CLI-related subcommands.