### PR TITLE
Handle trailing slash when building marketplace api path

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/mattermost/mattermost-marketplace/internal/model"
 	"github.com/pkg/errors"
@@ -33,7 +34,7 @@ func closeBody(r *http.Response) {
 }
 
 func (c *Client) buildURL(urlPath string, args ...interface{}) string {
-	return fmt.Sprintf("%s%s", c.Address, fmt.Sprintf(urlPath, args...))
+	return fmt.Sprintf("%s/%s", strings.TrimRight(c.Address, "/"), strings.TrimLeft(fmt.Sprintf(urlPath, args...), "/"))
 }
 
 func (c *Client) doGet(u string) (*http.Response, error) {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -19,12 +19,12 @@ func TestBuildURL(t *testing.T) {
 			path:     "/api/v1/plugins",
 			expected: "https://api.integrations.mattermost.com/api/v1/plugins",
 		},
-		"Base url with without trailing slash and path with leading slash": {
+		"Base url without trailing slash and path with leading slash": {
 			base:     "https://api.integrations.mattermost.com",
 			path:     "/api/v1/plugins",
 			expected: "https://api.integrations.mattermost.com/api/v1/plugins",
 		},
-		"Base url with without trailing slash and path without leading slash": {
+		"Base url without trailing slash and path without leading slash": {
 			base:     "https://api.integrations.mattermost.com",
 			path:     "api/v1/plugins",
 			expected: "https://api.integrations.mattermost.com/api/v1/plugins",

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildURL(t *testing.T) {
+	config := &Client{}
+
+	testCases := map[string]struct {
+		base     string
+		path     string
+		expected string
+	}{
+		"Base url with trailing slash and path with leading slash": {
+			base:     "https://api.integrations.mattermost.com/",
+			path:     "/api/v1/plugins",
+			expected: "https://api.integrations.mattermost.com/api/v1/plugins",
+		},
+		"Base url with without trailing slash and path with leading slash": {
+			base:     "https://api.integrations.mattermost.com",
+			path:     "/api/v1/plugins",
+			expected: "https://api.integrations.mattermost.com/api/v1/plugins",
+		},
+		"Base url with without trailing slash and path without leading slash": {
+			base:     "https://api.integrations.mattermost.com",
+			path:     "api/v1/plugins",
+			expected: "https://api.integrations.mattermost.com/api/v1/plugins",
+		},
+	}
+
+	for name, tt := range testCases {
+		t.Run(name, func(t *testing.T) {
+			config.Address = tt.base
+			actual := config.buildURL(tt.path)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Duplicates changes from https://github.com/mattermost/mattermost-server/pull/13273