### PR TITLE
Add generator add command

### DIFF
--- a/cmd/generator/add.go
+++ b/cmd/generator/add.go
@@ -23,8 +23,8 @@ var addCmd = &cobra.Command{
 	Use:   "add [repo] [tag]",
 	Short: "Add a plugin release to the plugins.json database",
 	Long: "The generator commands allows adding a specific plugin release to the database by using this command.\n\n" +
-		"The release has to be build first using the cut plugin command, which also uploads it to https://plugins-store.test.mattermost.com/release/. " +
-		"This localtion is used to fetch the plugin release.",
+		"The release has to be built first using the /mb cutPlugin command, which also uploads it to https://plugins-store.test.mattermost.com/release/. " +
+		"This location is used to fetch the plugin release.",
 	Example: `  generator add matterpoll v1.5.1`,
 	Args:    cobra.ExactArgs(2),
 	RunE: func(command *cobra.Command, args []string) error {

--- a/cmd/generator/add.go
+++ b/cmd/generator/add.go
@@ -20,8 +20,11 @@ func init() {
 }
 
 var addCmd = &cobra.Command{
-	Use:     "add [repo] [tag]",
-	Short:   "Add a plugin release to the plugins.json database",
+	Use:   "add [repo] [tag]",
+	Short: "Add a plugin release to the plugins.json database",
+	Long: "The generator commands allows adding a specific plugin release to the database by using this command.\n\n" +
+		"The release has to be build first using the cut plugin command, which also uploads it to https://plugins-store.test.mattermost.com/release/. " +
+		"This localtion is used to fetch the plugin release.",
 	Example: `  generator add matterpoll v1.5.1`,
 	Args:    cobra.ExactArgs(2),
 	RunE: func(command *cobra.Command, args []string) error {

--- a/cmd/generator/add.go
+++ b/cmd/generator/add.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"encoding/json"
+	"os"
+	"regexp"
+	"time"
+
+	mattermostModel "github.com/mattermost/mattermost-server/model"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/mattermost/mattermost-marketplace/internal/model"
+)
+
+func init() {
+	generatorCmd.AddCommand(addCmd)
+}
+
+var addCmd = &cobra.Command{
+	Use:     "add [repo] [tag]",
+	Short:   "Add a plugin release to the plugins.json database",
+	Example: `  generator add matterpoll v1.5.1`,
+	Args:    cobra.ExactArgs(2),
+	RunE: func(command *cobra.Command, args []string) error {
+		command.SilenceUsage = true
+
+		plugins, err := InitCommand(command)
+		if err != nil {
+			return err
+		}
+
+		repo := args[0]
+		tag := args[1]
+		if !regexp.MustCompile("v[0-9]+.[0-9]+.[0-9]+$").MatchString(tag) {
+			return errors.Errorf("bad tag. Maybe a typo? You set this tag %s but we expected something like v2.3.4", tag)
+		}
+
+		bundleURL := "https://plugins-store.test.mattermost.com/release/" + repo + "-" + tag + ".tar.gz"
+		signatureURL := bundleURL + ".sig"
+
+		bundleData, err := downloadBundleData(bundleURL)
+		if err != nil {
+			return errors.Wrapf(err, "failed download bundle data")
+		}
+
+		manifestData, err := getFromTarFile(tar.NewReader(bytes.NewReader(bundleData)), "plugin.json")
+		if err != nil {
+			return errors.Wrap(err, "failed to read manifest from plugin bundle for release")
+		}
+
+		manifest := mattermostModel.ManifestFromJson(bytes.NewReader(manifestData))
+		if manifest == nil {
+			return errors.New("manifest nil after reading from plugin bundle for release")
+		}
+
+		var iconData string
+		if manifest.IconPath != "" {
+			iconData, err = getIconDataFromTarFile(bundleData, manifest.IconPath)
+			if err != nil {
+				return errors.Wrap(err, "failed to set icon")
+			}
+		}
+
+		signature, err := downloadSignature(signatureURL)
+		if err != nil {
+			return errors.Wrap(err, "failed to download plugin signature")
+		}
+
+		plugin := &model.Plugin{
+			HomepageURL:     manifest.HomepageURL,
+			IconData:        iconData,
+			DownloadURL:     bundleURL,
+			ReleaseNotesURL: "", // Not jet supported
+			Labels:          nil,
+			Signature:       signature,
+			Manifest:        manifest,
+			UpdatedAt:       time.Now().In(time.UTC),
+		}
+		plugin.Signature = ""
+
+		plugins = append(plugins, plugin)
+		err = json.NewEncoder(os.Stdout).Encode(plugins)
+		if err != nil {
+			return errors.Wrap(err, "failed to encode plugins result")
+		}
+
+		return nil
+	},
+}

--- a/cmd/generator/add.go
+++ b/cmd/generator/add.go
@@ -47,7 +47,7 @@ var addCmd = &cobra.Command{
 
 		bundleData, err := downloadBundleData(bundleURL)
 		if err != nil {
-			return errors.Wrapf(err, "failed download bundle data")
+			return errors.Wrapf(err, "failed downloading bundle data")
 		}
 
 		manifestData, err := getFromTarFile(tar.NewReader(bytes.NewReader(bundleData)), "plugin.json")
@@ -64,7 +64,7 @@ var addCmd = &cobra.Command{
 		if manifest.IconPath != "" {
 			iconData, err = getIconDataFromTarFile(bundleData, manifest.IconPath)
 			if err != nil {
-				return errors.Wrap(err, "failed to set icon")
+				return errors.Wrap(err, "failed to get icon")
 			}
 		}
 
@@ -83,7 +83,6 @@ var addCmd = &cobra.Command{
 			Manifest:        manifest,
 			UpdatedAt:       time.Now().In(time.UTC),
 		}
-		plugin.Signature = ""
 
 		plugins = append(plugins, plugin)
 		err = json.NewEncoder(os.Stdout).Encode(plugins)

--- a/cmd/generator/add.go
+++ b/cmd/generator/add.go
@@ -5,9 +5,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
-	"regexp"
 	"time"
 
+	"github.com/blang/semver"
 	mattermostModel "github.com/mattermost/mattermost-server/model"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -34,8 +34,9 @@ var addCmd = &cobra.Command{
 
 		repo := args[0]
 		tag := args[1]
-		if !regexp.MustCompile("v[0-9]+.[0-9]+.[0-9]+$").MatchString(tag) {
-			return errors.Errorf("bad tag. Maybe a typo? You set this tag %s but we expected something like v2.3.4", tag)
+
+		if _, err = semver.ParseTolerant(tag); err != nil {
+			return errors.Wrapf(err, "%v is an invalid tag. Something like v2.3.4 is expected", tag)
 		}
 
 		bundleURL := "https://plugins-store.test.mattermost.com/release/" + repo + "-" + tag + ".tar.gz"

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/google/go-github/v28/github"
-	"github.com/h2non/filetype"
 	svg "github.com/h2non/go-is-svg"
 	mattermostModel "github.com/mattermost/mattermost-server/model"
 	"github.com/pkg/errors"
@@ -431,16 +430,11 @@ func getIconDataFromPath(path string) (string, error) {
 		return "", errors.Wrapf(err, "failed to open icon at path %s", path)
 	}
 
-	if svg.Is(icon) {
-		return fmt.Sprintf("data:image/svg+xml;base64,%s", base64.StdEncoding.EncodeToString(icon)), nil
+	if !svg.Is(icon) {
+		return "", errors.Wrapf(err, "icon at path %s is not svg", path)
 	}
 
-	kind, err := filetype.Image(icon)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to match icon to image")
-	}
-
-	return fmt.Sprintf("data:%s;base64,%s", kind.MIME, base64.StdEncoding.EncodeToString(icon)), nil
+	return fmt.Sprintf("data:image/svg+xml;base64,%s", base64.StdEncoding.EncodeToString(icon)), nil
 }
 
 // InitCommand parses the persistent flags and returns a list of existing plugins, if existing flag is defined.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/google/go-github/v28 v28.0.0
 	github.com/gorilla/mux v1.7.3
-	github.com/h2non/filetype v1.0.10
 	github.com/h2non/go-is-svg v0.0.0-20160927212452-35e8c4b0612c
 	github.com/mattermost/mattermost-server v0.0.0-20191025180218-37e042497717
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,6 @@ github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:Fecb
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/grpc-ecosystem/grpc-gateway v1.6.2/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
-github.com/h2non/filetype v1.0.10 h1:z+SJfnL6thYJ9kAST+6nPRXp1lMxnOVbMZHNYHMar0s=
-github.com/h2non/filetype v1.0.10/go.mod h1:isekKqOuhMj+s/7r3rIeTErIRy4Rub5uBWHfvMusLMU=
 github.com/h2non/go-is-svg v0.0.0-20160927212452-35e8c4b0612c h1:fEE5/5VNnYUoBOj2I9TP8Jc+a7lge3QWn9DKE7NCwfc=
 github.com/h2non/go-is-svg v0.0.0-20160927212452-35e8c4b0612c/go.mod h1:ObS/W+h8RYb1Y7fYivughjxojTmIu5iAIjSrSLCLeqE=
 github.com/hako/durafmt v0.0.0-20190612201238-650ed9f29a84/go.mod h1:5Scbynm8dF1XAPwIwkGPqzkM/shndPm79Jd1003hTjE=


### PR DESCRIPTION
#### Summary
This PR add a `generator add` command, which is used to add community plugins to the Marketplace Database.

To update the database you would e.g. run `go run ./cmd/generator/ add matterpoll v1.5.0 | jq | sponge plugins.json`.

I did a lot of refactoring in `cmd/generator/main.go` to keep the code DRY. I've rebuild the database from scratch and there was no difference to the existing one. Hence, I'm confident, I didn't add a regression.

I've tested the changes by downloading the release from https://github.com/hanzei/plugin-test/releases/tag/v1.4.0. The generated changed to the database can be found below.

`release_notes_url` is not set, because there is not mechanism in the manifest to define it and we can't rely on the GitHub URL, as the repo might not be located at GitHub.

`signature` is not set, because there is not signature for that release. I'm working with @cpanato to test this command with a plugin that also has a signature.

<details>
<summary>Details</summary>
```json
 {
    "homepage_url": "https://github.com/matterpoll/matterpoll",
    "icon_data": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iNjFweCIgaGVpZ2h0PSI2MXB4IiB2aWV3Qm94PSIwIDAgNjEgNjEiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8IS0tIEdlbmVyYXRvcjogU2tldGNoIDU5ICg4NjEyNykgLSBodHRwczovL3NrZXRjaC5jb20gLS0+CiAgICA8dGl0bGU+TG9nbyBEYXJrPC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPGcgaWQ9IkNvbG9yZWQtLS0iIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xODYuMDAwMDAwLCAtMjUwLjAwMDAwMCkiIGZpbGw9IiMwMDAwMDAiPgogICAgICAgICAgICA8ZyBpZD0iTG9nby1EYXJrIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxODYuMDAwMDAwLCAyNTAuMDAwMDAwKSI+CiAgICAgICAgICAgICAgICA8cGF0aCBkPSJNMjQuNzY5NzQ2MywwLjAwMDEzNTYwMjk3NyBMMjQuNzcwMzczNiwxMS43Njk4Mjc4IEMxNy4wMzk5MjU3LDE0LjE5Nzg2MjMgMTEuNDMyNTIwNSwyMS40MTk5MzkxIDExLjQzMjUyMDUsMjkuOTUxNjk1NSBDMTEuNDMyNTIwNSwzOC40ODM0NTE5IDE3LjAzOTkyNTcsNDUuNzA1NTI4NyAyNC43NzAzNzM2LDQ4LjEzMzU2MzIgTDI0Ljc3LDYwLjQzOCBMMiw2MC40Mzg0MTY5IEMwLjg5NTQzMDUsNjAuNDM4NDE2OSAtMS40MjEwODU0N2UtMTQsNTkuNTQyOTg2NCAtMS4wNjU4MTQxZS0xNCw1OC40Mzg0MTY5IEwwLDI4LjA0NjI3NTQgTDAuMDU4NTkxOTg4MywyOC4wNDYwMjI2IEMwLjkyMzYxNDMyNCwxNC4wMjA1NTA1IDExLjI3MTYxMTMsMi41NjA5NzU5NyAyNC43Njk3NDYzLDAuMDAwMTM1NjAyOTc3IFogTTYwLjgxNDQ4NzgsMjYuODE5MzI3MyBDNjAuOTE5NTkzNywyNy44NDkxNDQ3IDYwLjk3MzQ0MjgsMjguODk0MTMxNSA2MC45NzM0NDI4LDI5Ljk1MTY5NTUgQzYwLjk3MzQ0MjgsNDQuODM1MzUxNiA1MC4zMDc4NjY3LDU3LjIyNzkyOSAzNi4yMDI2OTcxLDU5LjkwMzQ0NSBMMzYuMjAzMDY5MSw0OC4xMzM1NjMyIEM0My45MzM1MTcsNDUuNzA1NTI4NyA0OS41NDA5MjIyLDM4LjQ4MzQ1MTkgNDkuNTQwOTIyMiwyOS45NTE2OTU1IEw0OS41MzksMjkuODQgWiBNMzYuMjAyNjk3MSwtNS4zOTc3OTcwOWUtMDUgQzQ1LjQ5MTA4NzksMS43NjE3OTkyNCA1My4yODc5NTA2LDcuNzM3MzEwNDQgNTcuNTI5ODg1MSwxNS44NjMwNzk3IEw0Ni4wNDA1MDUzLDE4Ljk0MjU1NSBDNDMuNjU5MTAwMywxNS41ODQxOTM3IDQwLjIxNzMyNCwxMy4wMzA2NTM4IDM2LjIwMzA2OTEsMTEuNzY5ODI3OCBaIiBpZD0iQ29tYmluZWQtU2hhcGUiPjwvcGF0aD4KICAgICAgICAgICAgPC9nPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+",
    "download_url": "https://github.com/hanzei/plugin-test/releases/download/v1.4.0/com.github.matterpoll.matterpoll-1.4.0.tar.gz",
    "release_notes_url": "",
    "labels": null,
    "signature": "",
    "manifest": {
      "id": "com.github.matterpoll.matterpoll",
      "name": "Matterpoll",
      "description": "Polling feature for Mattermost's custom slash command",
      "homepage_url": "https://github.com/matterpoll/matterpoll",
      "support_url": "https://github.com/matterpoll/matterpoll/issues",
      "icon_path": "assets/logo_dark.svg",
      "version": "1.4.0",
      "min_server_version": "5.14.0",
      "server": {
        "executables": {
          "linux-amd64": "server/dist/plugin-linux-amd64",
          "darwin-amd64": "server/dist/plugin-darwin-amd64",
          "windows-amd64": "server/dist/plugin-windows-amd64.exe"
        },
        "executable": ""
      },
      "webapp": {
        "bundle_path": "webapp/dist/main.js"
      },
      "settings_schema": {
        "header": "",
        "footer": "* To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/matterpoll/matterpoll).",
        "settings": [
          {
            "key": "Trigger",
            "display_name": "Trigger Word",
            "type": "text",
            "help_text": "Trigger Word must be unique, and cannot begin with a slash or contain any spaces.",
            "placeholder": "",
            "default": "poll"
          },
          {
            "key": "ExperimentalUI",
            "display_name": "Experimental UI",
            "type": "bool",
            "help_text": "When true, Matterpoll will render poll posts with a rich UI. The rich UI is not available on mobile app.",
            "placeholder": "",
            "default": false
          }
        ]
      }
    },
    "updated_at": "2020-01-15T12:26:29.104271951Z"
 }
```
</details>


#### Open Questions
- It it worth to add a make target e.g. `make add matterpoll v1.5.0`?
- With these changes it's not longer possible to remove the database and rebuild it from scratch. Are there situations where is behaviours is needed or wanted?

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21747

