### PR TITLE
Pin github.com/rakyll/statik version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: check-style test build
 ## Generate uses statikfs to bundle the plugin.json for use with the lambda function.
 .PHONY: generate
 generate:
-	go get github.com/rakyll/statik
+	go get github.com/rakyll/statik@v0.1.6
 	mkdir -p data/static/
 	cp plugins.json data/static/
 	go generate ./...


### PR DESCRIPTION
#### Summary

The Marketplace gets deployed as a aws lambda function. Because of this, we can only deploy a single binary and no additional files. The Marketplace uses `plugins.json` to store all available plugins, which we can't deploy to aws. To resolve this issue, `github.com/rakyll/statik` get used, which transforms `plugins.json` into a variable that gets build into the binary. You can find it in `data/statik/statik.go`. The CI makes sure that `data/statik/statik.go` gets updated every time, by re-generating it and checking if there are un committed changes. 

A new version `v0.1.7` of `github.com/rakyll/statik` was released a few days ago. The latest version did change the way the files are generated. This caused build failures like https://app.circleci.com/jobs/github/mattermost/mattermost-marketplace/188/parallel-runs/0/steps/0-109.

My pinning the version to `v0.1.6` we ensure that new release won't effect the builds.