### PR TITLE
Fix production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,11 +102,11 @@ jobs:
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
                 export AWS_ACCESS_KEY_ID=$AWS_STAGING_ACCESS_KEY_ID
                 export AWS_SECRET_ACCESS_KEY=$AWS_STAGING_SECRET_ACCESS_KEY
-                sudo -E sls deploy function -f server --stage staging
+                sudo -E serverless deploy function -f server --stage staging
             elif [ "${CIRCLE_BRANCH}" == "production" ]; then
                 export AWS_ACCESS_KEY_ID=$AWS_PRODUCTION_ACCESS_KEY_ID
                 export AWS_SECRET_ACCESS_KEY=$AWS_PRODUCTION_SECRET_ACCESS_KEY
-                sudo -E sls deploy function -f server --stage production
+                sudo -E serverless deploy function -f server --stage production
             else
                 echo "Unexpected branch ${CIRCLE_BRANCH}"
                 exit 1

--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,12 @@ build-lambda: generate
 ## Deploy the lambda stack
 .PHONY: deploy-lambda
 deploy-lambda: clean build-lambda
-	sls deploy --verbose --stage $(SLS_STAGE)
+	serverless deploy --verbose --stage $(SLS_STAGE)
 
 ## Deploy the lambda function only to an existing stack
 .PHONY: deploy-lambda-fast
 deploy-lambda-fast: clean build-lambda
-	sls deploy function -f server --stage $(SLS_STAGE)
+	serverless deploy function -f server --stage $(SLS_STAGE)
 
 ## Update plugins.json
 .PHONY: plugins.json


### PR DESCRIPTION
#### Summary
`sls` wasn't working on `master`, so I've fixed to use the `serverless` name instead. Confirmed a successful deploy via `master`.

The commit history here is noisy, since I'm basically just merging `master` to `production`, and the merge commit there wasn't part of the tree that Git was expecting. The actual delta of code, however, is up-to-date.