### PR TITLE
Bump node version for deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       - image: circleci/golang:1.14
   deploy:
     docker:
-      - image: circleci/node:8.10
+      - image: circleci/node:12
 
 references:
   workspace_root: &workspace_root


### PR DESCRIPTION
#### Summary
`serverless` will not soon not longer work with node < v10. (https://www.serverless.com/framework/docs/deprecations/#OUTDATED_NODEJS) Update the node version to the latest LTS version.

I've tested the changes by deploying to staging.