### PR TITLE
Update docs on how to add new releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ deploy-lambda-fast: clean build-lambda
 ## Update plugins.json
 .PHONY: plugins.json
 plugins.json:
+	@echo "This command is deprecated. Use go run ./cmd/generator/ add instead."
 	go run ./cmd/generator --database plugins.json --debug
 
 ## Clean all generated files

--- a/README.md
+++ b/README.md
@@ -66,11 +66,10 @@ go run ./cmd/generator/ add mattermost-plugin-jitsi v2.0.0 --official
 
 Make sure to double check the `diff` of `plugins.json` to ensure the release get added correctly.
 
-After you are satisfied with the changes, run
+After you are satisfied with the changes, run the following to update `data/statik/statik.go` and commit both the changes for `plugin.json` and `data/statik/statik.go`:
 ```
 make generate
 ```
-to update `data/statik/statik.go` and commit both the changes in `plugin.json` and `data/statik/statik.go`.
 
 ### Deploying as a Lambda Function
 

--- a/README.md
+++ b/README.md
@@ -54,32 +54,7 @@ make build-lambda
 
 ### Add a new release of a plugin to the Marketplace
 
-If you want added a new release of one of the following plugins:
-- Antivirus
-- Autolink
-- Aws-SNS
-- Custom-attributes
-- GitHub
-- GitLab
-- Jenkins
-- Jira
-- NPS
-- Webex
-- Welcomebot
-- Zoom
-
-run
-```
-make plugins.json
-```
-
-to fetch all new release of all of the above listed plugins from GitHub.
-
-If you run this command multiple times, GitHub might rate limit you. Using an API token does help:
-
-`export GITHUB_TOKEN=<github token>`
-
-To add a release of a plugin that is not on the list above, run
+To add a new release for a plugins, run
 ```
 go run ./cmd/generator/ add $REPOSITORY $VERSION [--official|--community]
 ```

--- a/README.md
+++ b/README.md
@@ -52,19 +52,50 @@ export BUILD_UPSTREAM_URL=https://api.integrations.mattermost.com
 make build-lambda
 ```
 
-### Updating plugins.json
+### Add a new release of a plugin to the Marketplace
 
-To fetch all new release from GitHub, run
+If you want added a new release of one of the following plugins:
+- Antivirus
+- Autolink
+- Aws-SNS
+- Custom-attributes
+- GitHub
+- GitLab
+- Jenkins
+- Jira
+- NPS
+- Webex
+- Welcomebot
+- Zoom
 
+run
 ```
 make plugins.json
 ```
 
-Make sure to double check the `diff` of `plugins.json` to ensure every release get added correctly.
+to fetch all new release of all of the above listed plugins from GitHub.
 
 If you run this command multiple times, GitHub might rate limit you. Using an API token does help:
 
 `export GITHUB_TOKEN=<github token>`
+
+To add a release of a plugin that is not on the list above, run
+```
+go run ./cmd/generator/ add $REPOSITORY $VERSION [--official|--community]
+```
+e.g.
+```
+go run ./cmd/generator/ add mattermost-plugin-jitsi v2.0.0 --official
+```
+`generator add` supports additional flags. See `generator add --help` for more details.
+
+Make sure to double check the `diff` of `plugins.json` to ensure the release get added correctly.
+
+After you are satisfied with the changes, run
+```
+make generate
+```
+to update `data/statik/statik.go` and commit both the changes in `plugin.json` and `data/statik/statik.go`.
 
 ### Deploying as a Lambda Function
 


### PR DESCRIPTION
#### Summary
`generator add` should be used to add releases for all not predefined plugins. This PR updated the documentation to make this clear.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-marketplace/issues/74

