### PR TITLE
Always use a <2.0.0 version of serverless

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
       - *attach_workspace
       - run:
           name: Install Serverless CLI and dependencies
-          command: sudo npm i -g serverless
+          command: sudo npm i -g serverless@"<2.0.0"
       - run:
           name: Deploy Function
           command: |


### PR DESCRIPTION
#### Summary
See the issue description for more infos.

I've tested the command locally and it does correctly install `v1.83.0`. Will cherry-pick the change once it's merged to unblock the deployments.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-marketplace/issues/118
