### PR TITLE
Run Marketplace migration commend concurrently

### DIFF
--- a/cmd/generator/add.go
+++ b/cmd/generator/add.go
@@ -74,10 +74,6 @@ var addCmd = &cobra.Command{
 			return err
 		}
 
-		if err = InitCommand(command); err != nil {
-			return err
-		}
-
 		dbFile, err := command.Flags().GetString("database")
 		if err != nil {
 			return err

--- a/cmd/generator/bundles.go
+++ b/cmd/generator/bundles.go
@@ -135,7 +135,7 @@ func checkIfRemoteBundlesExist(remotePluginHost, pluginWithVersion string) ([]st
 			return nil, err
 		}
 		if res.StatusCode != http.StatusOK {
-			logger.Infof("Platform-specific bundle not found %s %s", pluginWithVersion, path)
+			logger.Debugf("Platform-specific bundle not found %s %s", pluginWithVersion, path)
 			continue
 		}
 
@@ -146,7 +146,7 @@ func checkIfRemoteBundlesExist(remotePluginHost, pluginWithVersion string) ([]st
 			return nil, err
 		}
 		if res.StatusCode != http.StatusOK {
-			logger.Infof("Platform-specific bundle signature not found %s %s", pluginWithVersion, sigPath)
+			logger.Debugf("Platform-specific bundle signature not found %s %s", pluginWithVersion, sigPath)
 			continue
 		}
 

--- a/cmd/generator/bundles.go
+++ b/cmd/generator/bundles.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/mattermost/mattermost-marketplace/internal/model"
 )
@@ -40,15 +41,26 @@ var migrateCmd = &cobra.Command{
 			return errors.Wrap(err, "failed to read plugins from database")
 		}
 
+		var g errgroup.Group
 		toSave := []*model.Plugin{}
 		for _, orig := range existingPlugins {
-			var modified *model.Plugin
-			modified, err = addPlatformSpecificBundles(orig, pluginHost)
-			if err != nil {
-				return errors.Wrapf(err, "failed to add platform-specific bundles for plugin %s-%s", orig.Manifest.Id, orig.Manifest.Version)
-			}
+			orig := orig
 
-			toSave = append(toSave, modified)
+			g.Go(func() error {
+				var modified *model.Plugin
+				modified, err = addPlatformSpecificBundles(orig, pluginHost)
+				if err != nil {
+					return errors.Wrapf(err, "failed to add platform-specific bundles for plugin %s-%s", orig.Manifest.Id, orig.Manifest.Version)
+				}
+
+				toSave = append(toSave, modified)
+
+				return nil
+			})
+		}
+
+		if err = g.Wait(); err != nil {
+			return errors.Wrap(err, "failed to get a migrate a plugin to new structure")
 		}
 
 		err = pluginsToDatabase(dbFile, toSave)

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -49,17 +49,13 @@ func main() {
 }
 
 var generatorCmd = &cobra.Command{
-	Use:   "generator",
-	Short: "Generator is a tool to generate the plugins.json database",
+	Use:               "generator",
+	Short:             "Generator is a tool to generate the plugins.json database",
+	PersistentPreRunE: InitCommand,
 	// SilenceErrors allows us to explicitly log the error returned from generatorCmd below.
 	SilenceErrors: true,
 	RunE: func(command *cobra.Command, args []string) error {
 		command.SilenceUsage = true
-
-		err := InitCommand(command)
-		if err != nil {
-			return err
-		}
 
 		dbFile, err := command.Flags().GetString("database")
 		if err != nil {
@@ -453,7 +449,7 @@ func getIconDataFromTarFile(file []byte, path string) (string, error) {
 }
 
 // InitCommand parses the log level flag
-func InitCommand(command *cobra.Command) error {
+func InitCommand(command *cobra.Command, _ []string) error {
 	debug, err := command.Flags().GetBool("debug")
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/google/go-github/v28 v28.0.0
 	github.com/gorilla/mux v1.7.3
-	github.com/h2non/go-is-svg v0.0.0-20160927212452-35e8c4b0612c
 	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20200205094658-57717a23afa2
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.6
@@ -16,4 +15,5 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/oauth2 v0.0.0-20190319182350-c85d3e98c914
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 )

--- a/go.sum
+++ b/go.sum
@@ -437,6 +437,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost-marketplace/commit/bad8dfc4e7bbe13660ac4d72bcd040cb58702b20  makes the migration command run all the DB file migrations concurrently.

https://github.com/mattermost/mattermost-marketplace/commit/4d3d8612e7d80b36595ecfa537088ad7387804d4 ensure the log level is send consistently for all commands and log the message that is triggered when a platform-specific bundle is not found to `Debug`.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30263

