### PR TITLE
[MM-32278] Change "E20 Only" tag on listings to "E20 and Cloud"

### DIFF
--- a/internal/model/label.go
+++ b/internal/model/label.go
@@ -27,7 +27,7 @@ var BetaLabel Label = Label{
 }
 
 var EnterpriseLabel Label = Label{
-	Name:        "Enterprise (E20 and Cloud)",
+	Name:        "Enterprise (Cloud or E20)",
 	Description: "This plugin only works on servers with an E20 license or on Mattermost Cloud.",
 	URL:         "https://mattermost.com/pricing/",
 }

--- a/internal/model/label.go
+++ b/internal/model/label.go
@@ -27,7 +27,7 @@ var BetaLabel Label = Label{
 }
 
 var EnterpriseLabel Label = Label{
-	Name:        "Enterprise Edition E20 (Self-managed and Mattermost Cloud)",
+	Name:        "Enterprise (E20 and Cloud)",
 	Description: "This plugin only works on self-managed deployments (E20) and Mattermost Cloud workspaces.",
 	URL:         "https://mattermost.com/pricing/",
 }

--- a/internal/model/label.go
+++ b/internal/model/label.go
@@ -28,6 +28,6 @@ var BetaLabel Label = Label{
 
 var EnterpriseLabel Label = Label{
 	Name:        "Enterprise Edition E20 (Self-managed and Mattermost Cloud)",
-	Description: "This plugin only works on self-managed deployments using an Enterprise Edition E20 license and Mattermost Cloud workspaces.",
+	Description: "This plugin only works on self-managed deployments (E20) and Mattermost Cloud workspaces.",
 	URL:         "https://mattermost.com/pricing/",
 }

--- a/internal/model/label.go
+++ b/internal/model/label.go
@@ -27,7 +27,7 @@ var BetaLabel Label = Label{
 }
 
 var EnterpriseLabel Label = Label{
-	Name:        "Enterprise (Cloud or E20)",
+	Name:        "Enterprise Edition E20" (Self-managed and Mattermost Cloud),
 	Description: "This plugin only works on self-managed deployments using an Enterprise Edition E20 license and Mattermost Cloud workspaces.",
 	URL:         "https://mattermost.com/pricing/",
 }

--- a/internal/model/label.go
+++ b/internal/model/label.go
@@ -27,7 +27,7 @@ var BetaLabel Label = Label{
 }
 
 var EnterpriseLabel Label = Label{
-	Name:        "Enterprise Edition E20" (Self-managed and Mattermost Cloud),
+	Name:        "Enterprise Edition E20 (Self-managed and Mattermost Cloud)",
 	Description: "This plugin only works on self-managed deployments using an Enterprise Edition E20 license and Mattermost Cloud workspaces.",
 	URL:         "https://mattermost.com/pricing/",
 }

--- a/internal/model/label.go
+++ b/internal/model/label.go
@@ -27,7 +27,7 @@ var BetaLabel Label = Label{
 }
 
 var EnterpriseLabel Label = Label{
-	Name:        "Enterprise (E20)",
-	Description: "This plugin only works on servers with an E20 license.",
+	Name:        "Enterprise (E20 and Cloud)",
+	Description: "This plugin only works on servers with an E20 license or on Mattermost Cloud.",
 	URL:         "https://mattermost.com/pricing/",
 }

--- a/internal/model/label.go
+++ b/internal/model/label.go
@@ -28,6 +28,6 @@ var BetaLabel Label = Label{
 
 var EnterpriseLabel Label = Label{
 	Name:        "Enterprise (Cloud or E20)",
-	Description: "This plugin only works on servers with an E20 license or on Mattermost Cloud.",
+	Description: "This plugin only works on self-managed deployments using an Enterprise Edition E20 license and Mattermost Cloud workspaces.",
 	URL:         "https://mattermost.com/pricing/",
 }


### PR DESCRIPTION
#### Summary
Should it be "E20 and Cloud" or "Cloud and E20"?

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32278
