### PR TITLE
[MM-32593] Update golangci-lint to v1.33.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  tools: gotest/tools@0.0.13
+
 executors:
   build:
     docker:
@@ -28,35 +31,6 @@ commands:
               git status --porcelain
               exit 1
             fi
-  install-golangci-lint:
-    description: Install golangci-lint
-    parameters:
-      version:
-        type: string
-        default: 1.21.0
-      gobin:
-        type: string
-        default: /go/bin
-      prefix:
-        type: string
-        default: v1
-        description: Prefix for cache key to store the binary.
-    steps:
-      - restore_cache:
-          name: Restore golangci-lint cache
-          keys: ['<< parameters.prefix >>-golangci-lint-{{ arch }}-<< parameters.version >>']
-      - run:
-          name: Install golangci-lint
-          command: |
-            mkdir -p << parameters.gobin >>
-            command -v << parameters.gobin >>/golangci-lint && exit
-
-            download=https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
-            wget -O- -q $download | sh -s -- -b << parameters.gobin >>/ v<< parameters.version >>
-      - save_cache:
-          name: Save golangci-lint cache
-          key: '<< parameters.prefix >>-golangci-lint-{{ arch }}-<< parameters.version >>'
-          paths: [<< parameters.gobin >>/golangci-lint]
 
 jobs:
   build:
@@ -65,7 +39,8 @@ jobs:
     working_directory: *workspace_root
     steps:
       - checkout
-      - install-golangci-lint
+      - tools/install-golangci-lint:
+          version: 1.33.2
       - run: make check-style
       - run: make test
       - run: make build

--- a/internal/api/plugins.go
+++ b/internal/api/plugins.go
@@ -33,7 +33,7 @@ func parsePluginFilter(u *url.URL) (*model.PluginFilter, error) {
 	filter := u.Query().Get("filter")
 	serverVersion := u.Query().Get("server_version")
 	platform := u.Query().Get("platform")
-	pluginId := u.Query().Get("plugin_id")
+	pluginID := u.Query().Get("plugin_id")
 
 	enterprisePlugins, err := parseBool(u, "enterprise_plugins", false)
 	if err != nil {
@@ -58,7 +58,7 @@ func parsePluginFilter(u *url.URL) (*model.PluginFilter, error) {
 		EnterprisePlugins: enterprisePlugins,
 		Cloud:             cloud,
 		Platform:          platform,
-		PluginId:          pluginId,
+		PluginID:          pluginID,
 		ReturnAllVersions: returnAllVersions,
 	}, nil
 }

--- a/internal/model/plugin.go
+++ b/internal/model/plugin.go
@@ -138,5 +138,5 @@ type PluginFilter struct {
 	Cloud             bool
 	Platform          string
 	ReturnAllVersions bool
-	PluginId          string
+	PluginID          string
 }

--- a/internal/store/static.go
+++ b/internal/store/static.go
@@ -95,7 +95,7 @@ func (store *StaticStore) GetPlugins(pluginFilter *model.PluginFilter) ([]*model
 	filter := strings.TrimSpace(pluginFilter.Filter)
 	var filteredPlugins []*model.Plugin
 	for _, plugin := range plugins {
-		if pluginFilter.PluginId != "" && pluginFilter.PluginId != plugin.Manifest.Id {
+		if pluginFilter.PluginID != "" && pluginFilter.PluginID != plugin.Manifest.Id {
 			continue
 		}
 		if filter == "" || pluginMatchesFilter(plugin, filter) {

--- a/internal/store/static_test.go
+++ b/internal/store/static_test.go
@@ -403,7 +403,7 @@ func TestStaticGetPlugins(t *testing.T) {
 			Page:              0,
 			PerPage:           0,
 			Filter:            "",
-			PluginId:          "com.mattermost.demo-plugin",
+			PluginID:          "com.mattermost.demo-plugin",
 			ReturnAllVersions: true,
 		})
 		require.NoError(t, err)
@@ -415,7 +415,7 @@ func TestStaticGetPlugins(t *testing.T) {
 			Page:              0,
 			PerPage:           1,
 			Filter:            "",
-			PluginId:          "com.mattermost.demo-plugin",
+			PluginID:          "com.mattermost.demo-plugin",
 			ReturnAllVersions: true,
 		})
 		require.NoError(t, err)
@@ -427,7 +427,7 @@ func TestStaticGetPlugins(t *testing.T) {
 			Page:              0,
 			PerPage:           10,
 			Filter:            "",
-			PluginId:          "com.mattermost.demo-plugin",
+			PluginID:          "com.mattermost.demo-plugin",
 			ReturnAllVersions: true,
 		})
 		require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestStaticGetPlugins(t *testing.T) {
 			Page:              0,
 			PerPage:           1,
 			Filter:            "",
-			PluginId:          "com.mattermost.demo-plugin",
+			PluginID:          "com.mattermost.demo-plugin",
 			ReturnAllVersions: true,
 		})
 		require.NoError(t, err)
@@ -449,7 +449,7 @@ func TestStaticGetPlugins(t *testing.T) {
 	t.Run("default paging", func(t *testing.T) {
 		actualPlugins, err := staticStore.GetPlugins(&model.PluginFilter{PerPage: model.AllPerPage,
 			Filter:            "",
-			PluginId:          "com.mattermost.demo-plugin",
+			PluginID:          "com.mattermost.demo-plugin",
 			ReturnAllVersions: true,
 		})
 		require.NoError(t, err)
@@ -459,7 +459,7 @@ func TestStaticGetPlugins(t *testing.T) {
 	t.Run("plugins that satisfy 5.15", func(t *testing.T) {
 		actualPlugins, err := staticStore.GetPlugins(&model.PluginFilter{PerPage: model.AllPerPage,
 			ServerVersion:     "5.15.0",
-			PluginId:          "com.mattermost.demo-plugin",
+			PluginID:          "com.mattermost.demo-plugin",
 			ReturnAllVersions: true,
 		})
 		require.NoError(t, err)
@@ -469,7 +469,7 @@ func TestStaticGetPlugins(t *testing.T) {
 	t.Run("plugins that satisfy 5.14", func(t *testing.T) {
 		actualPlugins, err := staticStore.GetPlugins(&model.PluginFilter{PerPage: model.AllPerPage,
 			ServerVersion:     "5.14.0",
-			PluginId:          "com.mattermost.demo-plugin",
+			PluginID:          "com.mattermost.demo-plugin",
 			ReturnAllVersions: true,
 		})
 		require.NoError(t, err)
@@ -479,7 +479,7 @@ func TestStaticGetPlugins(t *testing.T) {
 	t.Run("with a server version that does not satisfy any plugin", func(t *testing.T) {
 		actualPlugins, err := staticStore.GetPlugins(&model.PluginFilter{PerPage: model.AllPerPage,
 			ServerVersion:     "5.13.0",
-			PluginId:          "com.mattermost.demo-plugin",
+			PluginID:          "com.mattermost.demo-plugin",
 			ReturnAllVersions: true,
 		})
 		require.NoError(t, err)


### PR DESCRIPTION
#### Summary
`golangci-lint` v1.33.2 is the default version used in most Mattermost repositories. This repo used a quite old version which missed some issues.

The PR also makes use of an orb instead of implementing the golangci-lint command itself.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32593