### PR TITLE
Add v0.8.2 of focalboard to the Marketplace

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -5381,6 +5381,60 @@
     "updated_at": "2020-11-23T19:52:34.710703726Z"
   },
   {
+    "homepage_url": "https://github.com/mattermost/focalboard",
+    "icon_data": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMjQxcHgiIGhlaWdodD0iMjQwcHgiIHZpZXdCb3g9IjAgMCAyNDEgMjQwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogICAgPCEtLSBHZW5lcmF0b3I6IFNrZXRjaCA0Ni4yICg0NDQ5NikgLSBodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2ggLS0+CiAgICA8dGl0bGU+Ymx1ZS1pY29uPC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPGcgaWQ9IjA2IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtNjgxLjAwMDAwMCwgLTU3Mi4wMDAwMDApIiBmaWxsPSIjMTg3NUYwIj4KICAgICAgICAgICAgPGcgaWQ9Ikdyb3VwLTIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDYyNi4wMDAwMDAsIDUxNy4wMDAwMDApIj4KICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik0yMTYuOTA4MTgxLDE1My4xMjc3MDUgQzIxNi45MDgxODEsMTUzLjEyNzcwNSAyMTcuMjgwNTg4LDE2OS40NTI1MjYgMjA1LjkyODc1NCwxODAuNTQzMDM1IEMxOTQuNTc1NDYsMTkxLjYzMzU0NCAxODAuNjMxMzgzLDE5MC42MTk4ODcgMTcxLjU2MDcyMiwxODcuNTU3MDcyIEMxNjIuNDg4NjAyLDE4NC40OTQyNTYgMTUwLjc5NTAzLDE3Ni44NTI1MSAxNDguNTMxMzgxLDE2MS4xNjcwNSBDMTQ2LjI2OTE5MywxNDUuNDgwMTMzIDE1Ni41MDgxODgsMTMyLjczNjYwNyAxNTYuNTA4MTg4LDEzMi43MzY2MDcgTDE3OC44MjA0NjMsMTA1LjA2NjQwNyBMMTkxLjgxNTI2OCw4OS4yNjI5Nzc5IEwyMDIuOTY5OTQ2LDc1LjQ5MTIzMTMgQzIwMi45Njk5NDYsNzUuNDkxMjMxMyAyMDguMDg4NzEzLDY4LjY1MzQxOTMgMjA5LjU0NzY3MSw2Ny4yNDIxNjQ4IEMyMDkuODM2ODM0LDY2Ljk2MjUzNTQgMjEwLjEzMzI5OSw2Ni43NzkwMjg2IDIxMC40MjM5MjMsNjYuNjM3NzU3NiBMMjEwLjYzNTY4Myw2Ni41Mjk5ODM3IEwyMTAuNjczNjU0LDY2LjUxNTQxOTcgQzIxMS4yODcwMyw2Ni4yNTE4MTA4IDIxMS45OTM4NzMsNjYuMTk1MDExIDIxMi42NzU4ODgsNjYuNDI1MTIyNyBDMjEzLjM0MzI5OSw2Ni42NTA4NjUyIDIxMy44NjAyODgsNjcuMTA4MTc1NyAyMTQuMTg3NDIxLDY3LjY3MTgwMzcgTDIxNC4yNTYwNjEsNjcuNzgxMDMzOSBMMjE0LjMxNTkzOCw2Ny45MDYyODQ2IEMyMTQuNDc1MTI0LDY4LjIwNjMwMzYgMjE0LjYwODAyMiw2OC41NDg1NTgzIDIxNC42NzA4Miw2OC45NzA5MTUxIEMyMTQuOTY4NzQ1LDcwLjk3NjM4MiAyMTQuODcwODk3LDc5LjUwOTQ0NzEgMjE0Ljg3MDg5Nyw3OS41MDk0NDcxIEwyMTUuMzQyNjEzLDk3LjIwNDc0MzQgTDIxNi4wMzkyMzIsMTE3LjYzMDc5NSBMMjE2LjkwODE4MSwxNTMuMTI3NzA1IFogTTI0NS43OTA1ODcsNzguMjA0MzI2MSBDMjg3LjA1NzIxMiwxMDguMTU1MjUzIDMwNS45ODI5MTUsMTYyLjUwOTY2OSAyODguNzc0Mjg4LDIxMy4zNDY4NzIgQzI2Ny41OTQxMDQsMjc1LjkxMTAzMSAxOTkuNzA2MjQ1LDMwOS40NjA3MyAxMzcuMTQyOTI1LDI4OC4yODE3MTggQzc0LjU3OTYwNDgsMjY3LjEwMTI1IDQxLjAzMTgxMiwxOTkuMjEzOTM3IDYyLjIxMDU0MDIsMTM2LjY0OTc3OCBDNzkuNDQ4Mjk0Nyw4NS43Mjk1NjAzIDEyNy42MjU0NTksNTQuMDMyNDA1NyAxNzguNjkwNjMyLDU1LjQxNDUzMjIgTDE2Mi4zMjIzMzksNzQuNzU0MTA3NCBDMTMyLjAyODEwNiw4MC4yMzE2MzkgMTA1Ljg3MTQ2LDEwMC45MTk4NDMgOTUuNTkwODQ4OSwxMzEuMjkwMjE1IEM4MC4yOTQ0NTM1LDE3Ni40NzUxMTcgMTA1LjkzMjYyOCwyMjUuOTgyNjI0IDE1Mi44NTU4NDYsMjQxLjg2NjE1NSBDMTk5Ljc3NzYwOCwyNTcuNzUxMTQyIDI1MC4yMTY1MzYsMjMzLjk5ODY2NiAyNjUuNTEyOTMyLDE4OC44MTM3NjQgQzI3NS43NjAwNDYsMTU4LjU0Mzg4NCAyNjcuNjM0ODgyLDEyNi4zMzY5ODggMjQ3LjA1MDM1OSwxMDMuNTk1MjU2IEwyNDUuNzkwNTg3LDc4LjIwNDMyNjEgWiIgaWQ9ImJsdWUtaWNvbiI+PC9wYXRoPgogICAgICAgICAgICA8L2c+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4=",
+    "download_url": "https://plugins-store.test.mattermost.com/release/focalboard-v0.8.2.tar.gz",
+    "release_notes_url": "https://github.com/mattermost/focalboard/releases",
+    "hosting": "cloud",
+    "author_type": "mattermost",
+    "release_stage": "production",
+    "enterprise": false,
+    "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmEJmkEACgkQ0bVLR6XO/sS24RAAm0da+OcMhiZAVfl93bCuilWdM+Kid0gwSfLnKMce7CfcjuooOUJ7wAE8AnGHiLyozqW5gQ8oA+psJbL0OG+IHhbibl2FHnFyjnnqF6cKcUdEWqg4pZcOqGHIQ/feCFNmKN/QNUfPN21qYpWqM6PIsefI7E4ZQ4hg4MwK2TnweY7INLfwAnwibfAbeXH/dgjkvxZOmRQ04BtJQkS4L5dMMJjuXXdKKh+D/v2ZKQJra/tu5Nsq+5m43+3J6b7r2t5aCaZK6Qvhw4KxSzjKWE8zVbJXW2/lXHM6l65YbRXd2xsDcOFseHXcHoYQrshwtfM6UoaTgOYkEUMc5rCn9g2PCmmVw+DH5xaP+lwWuU4sZaHlAOkxwn8QWS9w7M2ezwk7UGkXn/DUYJL+ucpiw16S1LjWN/i+7wFRH1XU9BRu6Y2+yY9d+slyo4RPvLefzFy5GM+stcCFqJo0sBGFILejdsGZ0rpd6EJ/xwbcwNbFhCVdLkun+7jpwDLKMWgej4niJdzPeozfKdDOaqAtf9hcjHVtBX6eJrFeb+ZRr3MT43oen1olvAwXMxfNjtZOptRITjssGgJ3nrStxkOnq9yMrhUMF7910Bh6/YpZbHw66Pm+gVwtCLURDuswU5m3tNJ/sOG7nnhK+pt7mDqzpONTsHd9YOBm0lbI5ObO5ig4k+M=",
+    "repo_name": "focalboard",
+    "manifest": {
+      "id": "focalboard",
+      "name": "Focalboard",
+      "description": "This provides focalboard integration with mattermost.",
+      "homepage_url": "https://github.com/mattermost/focalboard",
+      "support_url": "https://github.com/mattermost/focalboard/issues",
+      "release_notes_url": "https://github.com/mattermost/focalboard/releases",
+      "icon_path": "assets/starter-template-icon.svg",
+      "version": "0.8.2",
+      "min_server_version": "5.37.0",
+      "server": {
+        "executables": {
+          "linux-amd64": "server/dist/plugin-linux-amd64",
+          "darwin-amd64": "server/dist/plugin-darwin-amd64",
+          "windows-amd64": "server/dist/plugin-windows-amd64.exe"
+        },
+        "executable": ""
+      },
+      "webapp": {
+        "bundle_path": "webapp/dist/main.js"
+      },
+      "settings_schema": {
+        "header": "For additional setup steps, please [see here](https://focalboard.com/fwlink/plugin-setup.html)",
+        "footer": "",
+        "settings": []
+      }
+    },
+    "platforms": {
+      "linux-amd64": {
+        "download_url": "https://plugins-store.test.mattermost.com/release/focalboard-v0.8.2-linux-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmEJmj8ACgkQ0bVLR6XO/sTMaw//YLtiTsQV99fnINMJL8mkxHZcIJ6uUb7Zc6l4TbGQjScK6ml5UIjjJpqi19M0tafJ8g51F5PjqBrc8iPpCp0IZt9dpjnE/FE/5uC1eDHI092dJy/G3x+RED70v/hyjopxRWRo7PhxeOQz9y3YOXE8+Bb3ap697fx2eSMuWjn2s/PH+ydqZVMLr0QBDlT+EKPNMQXLgr3DirnzsNdtz0PCJkS7teUYEokkOuamRvxyHCVizmsYTTL3ZwA7enGxQuJKxB+gT7uyhmL12HXQRXka/K8B15jk/Af2SIB8eJ5nIJfYqTXhBDSYqhukoIxjNTVRWfCE/zLnx24FxREPQdNEXtgSLVgg8VcdR+GutWgFAolGba0UnrhOESFe8ryrYS3drVu00sg18xuu7Z248JKZ0V8dIehVAswWdGEKQaPmP0o/Ejy3UCS2csE2VdeWdyyddQeVaePCYlLgGxPWe+eWllgKhGCndN54O7QwDbmaoUOeBbGTZbc+pSbRKWWBM82Elr/1wB++xCV63h0Vo5L4UzswU+Wt/yCqKdLT5yv070vzf/kDXh5U/GOo6MSGE+EhDCJfNsa+rBqtuIofZ1jtROSHujA48YsU5ZGaROaZpZZhQEElo/Gr2itKZH7PClRowc+dB4rKUIMd/ztV44DibrOGv69dJy5yUFPpAo/sNZM="
+      },
+      "darwin-amd64": {
+        "download_url": "https://plugins-store.test.mattermost.com/release/focalboard-v0.8.2-osx-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmEJmjwACgkQ0bVLR6XO/sQ78Q//fTrvJHcltCuTLk8RBVTfH56xp2tlO+HEjMm7EFwrUy93wMXzVRxykTyCmGbeedubsfqed7AlwHD9HHB0GNTNjdfrjCsj3UvZKD9lIRgTZGHETKHb2ZQULw1x0fHDl5JhfHWJPtfrxgTlwxA/mc5QV0CyzJKayQOHqn/qj4Rj5aWo2/43nfUR38t93VQvFt1xt5HIHCoeBLfkG6rG9OLMwoQnCUbZEHbPOEd97BEnvWReipTCKUyRqdzv8bNvo7dypZ4ZB9ar0p81/Yfjwjr5hRUKaeAfxbSpb98ziOoIoHYaBlsZM09HGwU67XtUcgJZJZjgdXPXtrCQNMtWpVQTQXWp46vQYCTBGwLb++xMC5xFOwAXvaFD3GmbHPZ5gKDt/rEczmUUgrBcJCR7XUOMCFYnbIBZy77yoI7nWx7dFCU3BRtLG/xzVqx50LvDIV3rb0MLrAYriqfCGismo63FAgnd7Mo66//pF2TOcymQMGulXQGaHKmAtXddBEFsTxE2dxaS5wonAWhMybV0FaDTM5eN7zhpSCi72ak49DGvi3pveBAiAw+KNzNH5Yl9LeQZwk4EWXgh4P+IC5zz2PejbfEmLZIwhWaoRphbM9cjsRxD3YMFkvHi1ivmJ5SUke2q8cYx5gla/HiJJH/xLR7DzeOGRLoLtlmCJRkMoHuoCRA="
+      },
+      "windows-amd64": {
+        "download_url": "https://plugins-store.test.mattermost.com/release/focalboard-v0.8.2-windows-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmEJmj0ACgkQ0bVLR6XO/sRf3BAAjVHFProp5BpCMNFuYo4HBU/nxGcMwmSZcmVjAYZ+Ovg9vZGP29gYfDDIl9I8bHxAVtfY1k4NkotD+1LErFajBGqM3Kmu2LZmY7qN4gr6ZEDbYoWKkR0ocWnF+5MdibglT4eTwq3O0dm37UmZzDYc07tmsBqIn5BaSRMV8lWXg12x+kWuyNXYRDs9wor5MQT9MY5MKmUjzmLH76eL3SFRWgwscEgm3KYpCwhuo4M9VXU/spiqRw/MpBxdPcS9rABzAEkeZ3tOiIb4xZxp5YbZVun12VSmOHa+IQBzLErLMVbGSfwHNQZlz5WWttqu3Hkdt3yW9xadDBnIz738V4lcS3LXLJ4XxgufpuAepftzfF1NqW4sRchhC+ZOOn+fJCTz0RCXKMAKjvqR+dK8aIuG2YI5EVL5W0gShOkEZuVub4bl5kYtbBJSaBv9RbuEPiA8n22T1OiGmyRwi0nBF/BS8LkZ57txy431CE3Fo2g+vqonTShq+dkdP0vc5UlNHQr5WBMn/QaTfNoEmAW2W+a/61l5agiLBq66NC8WpxJX19YyUJzG4uWIIjbSmnuNKEdJkog8YoteJzzgNSKUaAINXy6DwoA64BHH9b2jFTR+OuTuJ92jNuOfZ9/RgwZulQmxuQmUozQxeX3fLj+cDR4qSGUvAkxUeDBHtLWrXnlqiEY="
+      }
+    },
+    "updated_at": "2021-08-03T19:36:52.817195Z"
+  },
+  {
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-github",
     "icon_data": "data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+R2l0SHViIGljb248L3RpdGxlPjxwYXRoIGQ9Ik0xMiAuMjk3Yy02LjYzIDAtMTIgNS4zNzMtMTIgMTIgMCA1LjMwMyAzLjQzOCA5LjggOC4yMDUgMTEuMzg1LjYuMTEzLjgyLS4yNTguODItLjU3NyAwLS4yODUtLjAxLTEuMDQtLjAxNS0yLjA0LTMuMzM4LjcyNC00LjA0Mi0xLjYxLTQuMDQyLTEuNjFDNC40MjIgMTguMDcgMy42MzMgMTcuNyAzLjYzMyAxNy43Yy0xLjA4Ny0uNzQ0LjA4NC0uNzI5LjA4NC0uNzI5IDEuMjA1LjA4NCAxLjgzOCAxLjIzNiAxLjgzOCAxLjIzNiAxLjA3IDEuODM1IDIuODA5IDEuMzA1IDMuNDk1Ljk5OC4xMDgtLjc3Ni40MTctMS4zMDUuNzYtMS42MDUtMi42NjUtLjMtNS40NjYtMS4zMzItNS40NjYtNS45MyAwLTEuMzEuNDY1LTIuMzggMS4yMzUtMy4yMi0uMTM1LS4zMDMtLjU0LTEuNTIzLjEwNS0zLjE3NiAwIDAgMS4wMDUtLjMyMiAzLjMgMS4yMy45Ni0uMjY3IDEuOTgtLjM5OSAzLS40MDUgMS4wMi4wMDYgMi4wNC4xMzggMyAuNDA1IDIuMjgtMS41NTIgMy4yODUtMS4yMyAzLjI4NS0xLjIzLjY0NSAxLjY1My4yNCAyLjg3My4xMiAzLjE3Ni43NjUuODQgMS4yMyAxLjkxIDEuMjMgMy4yMiAwIDQuNjEtMi44MDUgNS42MjUtNS40NzUgNS45Mi40Mi4zNi44MSAxLjA5Ni44MSAyLjIyIDAgMS42MDYtLjAxNSAyLjg5Ni0uMDE1IDMuMjg2IDAgLjMxNS4yMS42OS44MjUuNTdDMjAuNTY1IDIyLjA5MiAyNCAxNy41OTIgMjQgMTIuMjk3YzAtNi42MjctNS4zNzMtMTItMTItMTIiLz48L3N2Zz4=",
     "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-github-v2.0.1.tar.gz",


### PR DESCRIPTION
#### Summary
Publish Focalboard plugin v0.8.2 to the Marketplace for Cloud only.

I plan to merge this PR instead of the one for v0.8.1 (#208).