### PR TITLE
Add v0.4.8 of mattermost-plugin-calls to the private-beta Marketplace

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2,6 +2,93 @@
   {
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
     "icon_data": "",
+    "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.4.8.tar.gz",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.4.8",
+    "hosting": "",
+    "author_type": "mattermost",
+    "release_stage": "beta",
+    "enterprise": false,
+    "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmJNxtMACgkQ0bVLR6XO/sSk6w//R6X219uKK/zwNLl2C3e7ACc8wKeErL4eDfUcsZufowwawZjBp7hEP6Vi9uz4k4FLNMy85utB3/GofCiUrgjwrzbi0F6z4Tj72D3b3d3WMXmudZUSsbIeX5POXYBHfK/9tGKOlumlDKrdFxk8KHgSSfMhbwmv04BjEOSDXk6S+UKJEB0VxOmQccrMuEVTumdfz5uigJVyU7JQUkLZ+QyPecf5lSTACGyM/lslHtfxCRix3o82hkAqdS24oQFxASReaj4ypWAUDZwBviHrNBjSVW9dhej6dxH6g/L+K0H5yN6zWnIcCjMwSw/OgrTidOWjNmQbtdmEwMgqDBQNg/n0aYMvC3/UUwMF1t3kjCQinNGYCJNAQXzhkr5jN2IZ4ufWPU0L8CH6QhFG8nxq4x0D2tcA617nmP1Rd3WrBiXBT7m8YoD6cDe70KKHzt4XmiGK7lGNpbgcS8ZgRVTycusoTEb8n688BpcksleU8uJlKQEBzR3Y3KRdzw7MjA8fblAo2xBmcAmNUlH6Ia6DiWyab1O2sUlF4CjRPCQB/mb8uiPc/qcivnJCsTVjERNof4FlFl1cyQnZ3Y/MxUvkUE+9IIi7WWegKQSS2KDKlp4+g7F0TqnBuL9SxM75mx6t+pssLKtrCLXUjtc6RjsfIAPdHvx1/4wpRhzmgAIaeurXxG8=",
+    "repo_name": "mattermost-plugin-calls",
+    "manifest": {
+      "id": "com.mattermost.calls",
+      "name": "Calls",
+      "description": "Integrates real-time voice communication in Mattermost",
+      "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
+      "support_url": "https://github.com/mattermost/mattermost-plugin-calls/issues",
+      "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.4.8",
+      "version": "0.4.8",
+      "min_server_version": "6.3.0",
+      "server": {
+        "executables": {
+          "linux-amd64": "server/dist/plugin-linux-amd64",
+          "darwin-amd64": "server/dist/plugin-darwin-amd64"
+        },
+        "executable": ""
+      },
+      "webapp": {
+        "bundle_path": "webapp/dist/main.js"
+      },
+      "settings_schema": {
+        "header": "",
+        "footer": "",
+        "settings": [
+          {
+            "key": "ICEHostOverride",
+            "display_name": "ICE Host Override",
+            "type": "text",
+            "help_text": "The IP (or hostname) to be used as the host ICE candidate. If empty, it defaults to resolving via STUN.",
+            "placeholder": "",
+            "default": ""
+          },
+          {
+            "key": "UDPServerPort",
+            "display_name": "RTC Server Port",
+            "type": "number",
+            "help_text": "The UDP port the RTC server will listen on.",
+            "placeholder": "8443",
+            "default": 8443
+          },
+          {
+            "key": "ICEServers",
+            "display_name": "ICE Servers",
+            "type": "text",
+            "help_text": "A comma separated list of ICE servers URLs (STUN/TURN) to use.",
+            "placeholder": "stun:example.com:3478",
+            "default": "stun:stun.global.calls.mattermost.com:3478"
+          },
+          {
+            "key": "AllowEnableCalls",
+            "display_name": "Allow Enable Calls",
+            "type": "bool",
+            "help_text": "When set to true, it allows channel admins to enable or disable calls in their channels. It also allows participants of DMs/GMs to enable or disable calls.",
+            "placeholder": "",
+            "default": false
+          },
+          {
+            "key": "DefaultEnabled",
+            "display_name": "Default Enabled Calls",
+            "type": "bool",
+            "help_text": "When set to true, calls will be possible in all channels where they are not explicitly disabled.",
+            "placeholder": "",
+            "default": true
+          }
+        ]
+      }
+    },
+    "platforms": {
+      "linux-amd64": {
+        "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.4.8-linux-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmJNxtIACgkQ0bVLR6XO/sTB4w//UulNBLs5LYFInx2w5jjdjxHOGZ7KzDWgz0SbMLP62d55fWbDtbBqWbU3GU6v4Pdnr2G6WmKlfRGLOSQafufNTEeL0+9dzDEEg1jbz6+s7L6F6viXj+ebYaQE2+sJw9yu15pga/cqTCgLt0IMgwF6cWwHTbT3QGbLGI0DV9vqlXzWZ6tsrN5kkQalVGpqwrn9fjv6gfEQ10ECIG8ThpxheXQtQmeN1a0NrGpEsdE/9gFuMvkMd3QifeK1lgEBDR8+lOV//BVtAHBRLBihB35edUWUgSNT2koJSAQpIsLswvztg6AsBlM2al117XXVsMpGWMdI0BWEm2D2dz9SijtLPR3L4Dr6PwLdcxBWVIhZs2zEXdA9rtmRrZUnggr8RmareYEjLKioue788poWktQT3rXHqPlnGu2nncXUI2NxExcZnTvJhrAhwxlH3f/lkl5vl7EKTAKUyrjZWVw3OdRHA/TepXq5u5km+WpyZCPOKYvMJ8e61PuX5dEf7x4uR904qvJ2ZAouMqPfBvTsXnPN7bADUsCm3o/Jcw04JjZCPyM0hI8c4uHBqsl1qpTg0vQNWk6kbR6vr5Okoq7HJJsjZ40pv6lTK+R6Quhf9b9XxucdOvMB1GnvorAf/fwli3OXA953Hi7Lq34hz88CzcMZafOqYmJuUvvRSqahyrvaDQI="
+      },
+      "darwin-amd64": {},
+      "windows-amd64": {}
+    },
+    "updated_at": "2022-04-06T17:05:46.7944Z"
+  },
+  {
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
+    "icon_data": "",
     "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.4.5.tar.gz",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.4.5",
     "hosting": "",


### PR DESCRIPTION
#### Summary
- cut with `/mb cutplugin --repo mattermost-plugin-calls --tag v0.4.8 --pre-release`
- this commit made with `go run ./cmd/generator/ add mattermost-plugin-calls v0.4.8 --official --beta `

#### Ticket Link
- none