### PR TITLE
MM-43497 - Add on-prem label to marketplace calls plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -3305,7 +3305,7 @@
     "icon_data": "",
     "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.4.8.tar.gz",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.4.8",
-    "hosting": "",
+    "hosting": "on-prem",
     "author_type": "mattermost",
     "release_stage": "beta",
     "enterprise": false,


### PR DESCRIPTION
#### Summary
- Calls is only available for on-prem installations at the moment.
- I think this should be all we need, @hanzei can you confirm?

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-43497

