### PR TITLE
Add v1.6.0 of mattermost-plugin-zoom to the Marketplace

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -10517,7 +10517,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-zoom",
     "icon_data": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iOTEyIiBoZWlnaHQ9IjkxMiIgdmlld0JveD0iMCAwIDkxMiA5MTIiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxjaXJjbGUgY3g9IjQ1NiIgY3k9IjQ1NiIgcj0iNDU2IiBmaWxsPSIjMkQ4Q0ZGIi8+CjxwYXRoIGQ9Ik0xOTkuNSAzNDkuMTI1QzE5OS41IDMzMy4zODUgMjEyLjI2IDMyMC42MjUgMjI4IDMyMC42MjVINDcwLjI1QzUyOS4yNzUgMzIwLjYyNSA1NzcuMTI1IDM2OC40NzUgNTc3LjEyNSA0MjcuNVY1NjIuODc1QzU3Ny4xMjUgNTc4LjYxNSA1NjQuMzY1IDU5MS4zNzUgNTQ4LjYyNSA1OTEuMzc1SDMwNi4zNzVDMjQ3LjM1IDU5MS4zNzUgMTk5LjUgNTQzLjUyNSAxOTkuNSA0ODQuNVYzNDkuMTI1WiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik02NzYuODE1IDU4My44MjlMNjE4LjI5MyA1MzguNjUzQzYxNC43OTcgNTM1Ljk1NSA2MTIuNzUgNTMxLjc4OSA2MTIuNzUgNTI3LjM3M1Y0MTMuMTI3QzYxMi43NSA0MDguNzExIDYxNC43OTcgNDA0LjU0NSA2MTguMjkzIDQwMS44NDdMNjc2LjgxNSAzNTYuNjcxQzY4MS4zNDUgMzUyLjAxNiA2ODcuNjc5IDM0OS4xMjUgNjk0LjY4OCAzNDkuMTI1QzcwOC40NiAzNDkuMTI1IDcxOS42MjUgMzYwLjI5IDcxOS42MjUgMzc0LjA2MlY1NjYuNDM4QzcxOS42MjUgNTgwLjIxIDcwOC40NiA1OTEuMzc1IDY5NC42ODggNTkxLjM3NUM2ODcuNjc5IDU5MS4zNzUgNjgxLjM0NSA1ODguNDg0IDY3Ni44MTUgNTgzLjgyOVoiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPgo=",
     "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-zoom-v1.6.0.tar.gz",
-    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-zoom/releases/tag/v1.5.1",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-zoom/releases/tag/v1.6.0",
     "hosting": "on-prem",
     "author_type": "mattermost",
     "release_stage": "production",
@@ -10530,9 +10530,9 @@
       "description": "Zoom audio and video conferencing plugin for Mattermost 5.2+.",
       "homepage_url": "https://github.com/mattermost/mattermost-plugin-zoom",
       "support_url": "https://github.com/mattermost/mattermost-plugin-zoom/issues",
-      "release_notes_url": "https://github.com/mattermost/mattermost-plugin-zoom/releases/tag/v1.5.1",
+      "release_notes_url": "https://github.com/mattermost/mattermost-plugin-zoom/releases/tag/v1.6.0",
       "icon_path": "assets/profile.svg",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "min_server_version": "5.12.0",
       "server": {
         "executables": {
@@ -10636,15 +10636,15 @@
     },
     "platforms": {
       "linux-amd64": {
-        "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-zoom-v1.5.1-linux-amd64.tar.gz",
+        "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-zoom-v1.6.0-linux-amd64.tar.gz",
         "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmFTTCYACgkQ0bVLR6XO/sSgRxAAlRfYHBqbgeBVSVuwwZooqkRPCa0VEqGRKs82iz0o5HV/BpZ3CNf0iNTJlD42ftIjiVHgB7JS4KMF+TpKqUD6GxW+fz40D0dqStyyP+YgYMP5GL23V3ml/gdEbnjBaOsT75tr4NMDAjR1cfk8QodIQMExe1Lr1eLqzK1JPZBVz1bdE2LKH7ZMSskgVdKCFYV3YaV7M0bNYMKalo/EMZ1RavtsUZPqVXHmJAzdREP/DWWaeokVenX2EHmr3zFFIaHGm4Ueq6jZFr9oEdUdK2CfhM8yo+pUth5oDuSOLoDUzcBvMKYDMhfYhWYuV/umA9wkEyJpQnlncht8BaaD5x+vUZ6VD7rupVmS5w3M4HleOXerXusT5RW8KsMmMGvNMUDgrS0qp/QtNqJDQuQ26P4qejOBF1TiBC36rBAqsJFH/aJR0Dtw9vVaW/JlkP1phF44Ya3FMVMuqTfekz2OdJKFytC3lXvPMLSdVFv7UcgHoU/J9GGjnVuzJ9jGhuda95TRb/loKSOcdwQOPmFhpNWj2YAgJxW97E73oyc/Sck2U7rhiG+n721/0iVbCHsNZCIYyTJ6BceizbeUqCoBXEkyCIIeTh74l1guBuNil+c58Kg0jXhU4bL6hqJH/JZNDQNKnCk9Ha1IT8JqxB2wbI01zxgAdgXQopi2zfTKGRBNkL0="
       },
       "darwin-amd64": {
-        "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-zoom-v1.5.1-osx-amd64.tar.gz",
+        "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-zoom-v1.6.0-osx-amd64.tar.gz",
         "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmFTTCMACgkQ0bVLR6XO/sReVBAAgjCYGEObO3mzY9AHbo1w5qfYtSePUx3sa+iiHjBM/yWPM/lT3kBu9VZq4pw/jrOS3iOPJOw0VTEI3ENOXm+PAPsVpUMSdWnhV5/BUIs9xYqXpsRZvaCrCeM6OfY4sDGTrXiMAqSJow6EtOnmFSZXkJfQVN3x5qOJJoCdUqYVQ8+LyLWBBDcM5aiuNqbDBw+Sp+EKCCxabimOr7pUene0doFNP68GXL4WErACbrCVOpUjSjcaSXFAmH8wC+nHtW2/BFJIJAHpUeegiIjgm/RZOcB7tw04G6gYV8+nUa0A8kCQicBTnCJq3YH5tuFFyytWLlPVqceH6b9FHNjuSnVXvmcuRjM/goIM6+B4FRR7hQj8uqxWVJUnQJxKBmCu7/vAaLGQCVslfKAJstTgUJtxsEWjSt5BAQvoTX1ts7R+PAnryoCSABCquEA7wqM0PM5pPes3KJDhj9AgI+6iHfZtCyAp+g2w4ZnlknVJRFrNucMqF8zHlthUEQgKyAQ7UxfWx89QR3WkVnVwKn+ul1Mu1vbkDEwTkeNerUVEbpFRxCxzpiXqJKUX4EUJOvxGrzIaNoN1QrKbRmnqUOOS+AkestlMKd0khiObWGtMChsMtvPNy+6Ef9ywgEYWr0gJBvhEgC3YuMO8MiJIlB3wDTdXZK/NhQODsSrBleboOQ1+JBY="
       },
       "windows-amd64": {
-        "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-zoom-v1.5.1-windows-amd64.tar.gz",
+        "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-zoom-v1.6.0-windows-amd64.tar.gz",
         "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmFTTCQACgkQ0bVLR6XO/sQUuw/+PLuGuayGdCzPEAQ7m2yrLiRxYY+YaHNuFfG/Q8XwE4gLQk5cENZ8q5dAjmcQHLRxVfmnQGRhDUgEbYI1qIXcztEvFUKAwnyzRFtlCEc88aZKnBWYf0FNNJULCs3egsoG9bndl/IfYvSqyvcYh6/DXAOgo2FG7wU2iOw+mT6SMGB5z1bm3XrtoeR6uuwKc2BYyT38Fom3rmEQjc9eemnPaQ5HZRJbjUhLVcQm114c89sBK7QUJ4MU9xcs1kcPD1l6KtgV+6NwoL+tsUCVUVgNQWfzUyLPOLaFwNUrBX/IpHCHvvq2rrSJvrEmrmdhyHBNwb16MCfA+RC7XkdsyRurhhm7vrrC/SjIEhDvvJwwHULbtv+lfp+whJLG3acizjJLzbtMua6uRo0PrBmWRoLHXT1h1h+VS7TAjAG9eRgCpl0hlw4yiwgDmgBEG/6w4huU12iJC0u6po9DW3XvcBXagFRQHboaPkZtLdHOomi/y9L/Vu6c0oZ0YMPr0HHbVFsQ4bwC1k2ExlpK6gNGis8NAkhkqMkEMbq1I5Z44BNaefZhjJWn/2C6Tf2ki+7PEEnQh4RfQGRJJELXJT1cxKApxE7V3izHa/WSehY0ibI33+vZFCvqHMeIdbBnwbm0KFfjepXTMRJxKYUlS2Cv8uMC294vNeBfrarXY261f/7qhzw="
       }
     },

--- a/plugins.json
+++ b/plugins.json
@@ -10516,6 +10516,143 @@
   {
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-zoom",
     "icon_data": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iOTEyIiBoZWlnaHQ9IjkxMiIgdmlld0JveD0iMCAwIDkxMiA5MTIiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxjaXJjbGUgY3g9IjQ1NiIgY3k9IjQ1NiIgcj0iNDU2IiBmaWxsPSIjMkQ4Q0ZGIi8+CjxwYXRoIGQ9Ik0xOTkuNSAzNDkuMTI1QzE5OS41IDMzMy4zODUgMjEyLjI2IDMyMC42MjUgMjI4IDMyMC42MjVINDcwLjI1QzUyOS4yNzUgMzIwLjYyNSA1NzcuMTI1IDM2OC40NzUgNTc3LjEyNSA0MjcuNVY1NjIuODc1QzU3Ny4xMjUgNTc4LjYxNSA1NjQuMzY1IDU5MS4zNzUgNTQ4LjYyNSA1OTEuMzc1SDMwNi4zNzVDMjQ3LjM1IDU5MS4zNzUgMTk5LjUgNTQzLjUyNSAxOTkuNSA0ODQuNVYzNDkuMTI1WiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik02NzYuODE1IDU4My44MjlMNjE4LjI5MyA1MzguNjUzQzYxNC43OTcgNTM1Ljk1NSA2MTIuNzUgNTMxLjc4OSA2MTIuNzUgNTI3LjM3M1Y0MTMuMTI3QzYxMi43NSA0MDguNzExIDYxNC43OTcgNDA0LjU0NSA2MTguMjkzIDQwMS44NDdMNjc2LjgxNSAzNTYuNjcxQzY4MS4zNDUgMzUyLjAxNiA2ODcuNjc5IDM0OS4xMjUgNjk0LjY4OCAzNDkuMTI1QzcwOC40NiAzNDkuMTI1IDcxOS42MjUgMzYwLjI5IDcxOS42MjUgMzc0LjA2MlY1NjYuNDM4QzcxOS42MjUgNTgwLjIxIDcwOC40NiA1OTEuMzc1IDY5NC42ODggNTkxLjM3NUM2ODcuNjc5IDU5MS4zNzUgNjgxLjM0NSA1ODguNDg0IDY3Ni44MTUgNTgzLjgyOVoiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPgo=",
+    "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-zoom-v1.6.0.tar.gz",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-zoom/releases/tag/v1.5.1",
+    "hosting": "on-prem",
+    "author_type": "mattermost",
+    "release_stage": "production",
+    "enterprise": false,
+    "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmKduCgACgkQ0bVLR6XO/sQMlRAAgGIaoNG0E6ZDFbhscqNeviFQhZPZDcDszYyeQ8heMBwlMVuq/6nchmaG5xoZIUQLmOPBeeSDr67Et4WvrJy7FsC84RxZdYynQoRpuStVfoj/pzyc2LK857GgH+XmL5fY7RGGmgCI9ZT+Yso4hdO+7dv4qpc4hIR9ZcOwBPtlPVpLpRqlRT5abUFEnzQZUduYD6uncSDedRkjCOaWHmop2+Ayk21qh3MQDXqpvBkGFskEpXYCsj5NEr30pSGWr+tSRWh4DpbrGhwHPkhVGyDaTMXw56QGi9P8hZ3NuMvkyvWTQmCcTOLDKUK8+nnW8a6sCvcvIuOtMqnUkMkuSk5r5gnOoh1eB8zOTgrdNUkNcrMFgkiC/xusRq3qBAXGVsywDL6mjSpBwruKwQ5F6b8w8Ftl/x0V5NktqqixpobR5lm11vCh7Scu5AGoSH3jFHA5VyP3lYGxY6hr6OQMC+0VHpZBfqLIJtG6AQcSutmMN5RLnov6Ksbz1c3mV7iXMbaOocp1pU8ZVbo/3MJjzCzz/9ChJ0kFD/KPEdJJiJDJ8Jlw9zvxfRt0tNt3fAFZj9+LgFh2dncdxoS2a7O2uFwdTLP2JA/HoqW0H/JrrEW6/QgMjaVp7ygMI2SeehE7pEzXWI5n/dKMLAktw1O5Uzk0hOhW+O5LRk9ZIsBmv9Hv8KA=",
+    "repo_name": "mattermost-plugin-zoom",
+    "manifest": {
+      "id": "zoom",
+      "name": "Zoom",
+      "description": "Zoom audio and video conferencing plugin for Mattermost 5.2+.",
+      "homepage_url": "https://github.com/mattermost/mattermost-plugin-zoom",
+      "support_url": "https://github.com/mattermost/mattermost-plugin-zoom/issues",
+      "release_notes_url": "https://github.com/mattermost/mattermost-plugin-zoom/releases/tag/v1.5.1",
+      "icon_path": "assets/profile.svg",
+      "version": "1.5.1",
+      "min_server_version": "5.12.0",
+      "server": {
+        "executables": {
+          "linux-amd64": "server/dist/plugin-linux-amd64",
+          "darwin-amd64": "server/dist/plugin-darwin-amd64",
+          "windows-amd64": "server/dist/plugin-windows-amd64.exe"
+        },
+        "executable": ""
+      },
+      "webapp": {
+        "bundle_path": "webapp/dist/main.js"
+      },
+      "settings_schema": {
+        "header": "To set up this plugin you first need to create a Zoom App using a Zoom Administrator account. Visit the [documentation for configuration steps](https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration).",
+        "footer": "",
+        "settings": [
+          {
+            "key": "ZoomURL",
+            "display_name": "Zoom URL:",
+            "type": "text",
+            "help_text": "The URL for a self-hosted private cloud or on-prem Zoom server. For example, https://yourzoom.com. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
+            "placeholder": "https://zoom.us",
+            "default": null
+          },
+          {
+            "key": "ZoomAPIURL",
+            "display_name": "Zoom API URL:",
+            "type": "text",
+            "help_text": "The API URL for a self-hosted private cloud or on-prem Zoom server. For example, https://api.yourzoom.com/v2. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
+            "placeholder": "https://api.zoom.us/v2",
+            "default": null
+          },
+          {
+            "key": "EnableOAuth",
+            "display_name": "Enable OAuth:",
+            "type": "bool",
+            "help_text": "When true, OAuth will be used as the authentication means with Zoom. \n When false, JWT will be used as the authentication means with Zoom. \n If you're currently using a JWT Zoom application and switch to OAuth, all users will need to connect their Zoom account using OAuth the next time they try to start a meeting. [More information](https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration).",
+            "placeholder": "",
+            "default": false
+          },
+          {
+            "key": "AccountLevelApp",
+            "display_name": "OAuth by Account Level App (Beta):",
+            "type": "bool",
+            "help_text": "When true, only an account administrator has to log in. The rest of the users will use their email to log in.",
+            "placeholder": "",
+            "default": false
+          },
+          {
+            "key": "OAuthClientID",
+            "display_name": "Zoom OAuth Client ID:",
+            "type": "text",
+            "help_text": "The client ID for the OAuth app registered with Zoom. Leave blank if not using OAuth.",
+            "placeholder": "",
+            "default": null
+          },
+          {
+            "key": "OAuthClientSecret",
+            "display_name": "Zoom OAuth Client Secret:",
+            "type": "text",
+            "help_text": "The client secret for the OAuth app registered with Zoom. Leave blank if not using OAuth.",
+            "placeholder": "",
+            "default": null
+          },
+          {
+            "key": "EncryptionKey",
+            "display_name": "At Rest Token Encryption Key:",
+            "type": "generated",
+            "help_text": "The AES encryption key used to encrypt stored access tokens.",
+            "regenerate_help_text": "Regenerates the encryption key for Zoom OAuth token. Regenerating the key invalidates your existing Zoom OAuth.",
+            "placeholder": "",
+            "default": null
+          },
+          {
+            "key": "APIKey",
+            "display_name": "API Key:",
+            "type": "text",
+            "help_text": "The API key generated by Zoom, used to create meetings and pull user data.",
+            "placeholder": "",
+            "default": null
+          },
+          {
+            "key": "APISecret",
+            "display_name": "API Secret:",
+            "type": "text",
+            "help_text": "The API secret generated by Zoom for your API key.",
+            "placeholder": "",
+            "default": null
+          },
+          {
+            "key": "WebhookSecret",
+            "display_name": "Webhook Secret:",
+            "type": "generated",
+            "help_text": "The secret used to authenticate the webhook to Mattermost.",
+            "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Zoom plugin.",
+            "placeholder": "",
+            "default": null
+          }
+        ]
+      }
+    },
+    "platforms": {
+      "linux-amd64": {
+        "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-zoom-v1.5.1-linux-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmFTTCYACgkQ0bVLR6XO/sSgRxAAlRfYHBqbgeBVSVuwwZooqkRPCa0VEqGRKs82iz0o5HV/BpZ3CNf0iNTJlD42ftIjiVHgB7JS4KMF+TpKqUD6GxW+fz40D0dqStyyP+YgYMP5GL23V3ml/gdEbnjBaOsT75tr4NMDAjR1cfk8QodIQMExe1Lr1eLqzK1JPZBVz1bdE2LKH7ZMSskgVdKCFYV3YaV7M0bNYMKalo/EMZ1RavtsUZPqVXHmJAzdREP/DWWaeokVenX2EHmr3zFFIaHGm4Ueq6jZFr9oEdUdK2CfhM8yo+pUth5oDuSOLoDUzcBvMKYDMhfYhWYuV/umA9wkEyJpQnlncht8BaaD5x+vUZ6VD7rupVmS5w3M4HleOXerXusT5RW8KsMmMGvNMUDgrS0qp/QtNqJDQuQ26P4qejOBF1TiBC36rBAqsJFH/aJR0Dtw9vVaW/JlkP1phF44Ya3FMVMuqTfekz2OdJKFytC3lXvPMLSdVFv7UcgHoU/J9GGjnVuzJ9jGhuda95TRb/loKSOcdwQOPmFhpNWj2YAgJxW97E73oyc/Sck2U7rhiG+n721/0iVbCHsNZCIYyTJ6BceizbeUqCoBXEkyCIIeTh74l1guBuNil+c58Kg0jXhU4bL6hqJH/JZNDQNKnCk9Ha1IT8JqxB2wbI01zxgAdgXQopi2zfTKGRBNkL0="
+      },
+      "darwin-amd64": {
+        "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-zoom-v1.5.1-osx-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmFTTCMACgkQ0bVLR6XO/sReVBAAgjCYGEObO3mzY9AHbo1w5qfYtSePUx3sa+iiHjBM/yWPM/lT3kBu9VZq4pw/jrOS3iOPJOw0VTEI3ENOXm+PAPsVpUMSdWnhV5/BUIs9xYqXpsRZvaCrCeM6OfY4sDGTrXiMAqSJow6EtOnmFSZXkJfQVN3x5qOJJoCdUqYVQ8+LyLWBBDcM5aiuNqbDBw+Sp+EKCCxabimOr7pUene0doFNP68GXL4WErACbrCVOpUjSjcaSXFAmH8wC+nHtW2/BFJIJAHpUeegiIjgm/RZOcB7tw04G6gYV8+nUa0A8kCQicBTnCJq3YH5tuFFyytWLlPVqceH6b9FHNjuSnVXvmcuRjM/goIM6+B4FRR7hQj8uqxWVJUnQJxKBmCu7/vAaLGQCVslfKAJstTgUJtxsEWjSt5BAQvoTX1ts7R+PAnryoCSABCquEA7wqM0PM5pPes3KJDhj9AgI+6iHfZtCyAp+g2w4ZnlknVJRFrNucMqF8zHlthUEQgKyAQ7UxfWx89QR3WkVnVwKn+ul1Mu1vbkDEwTkeNerUVEbpFRxCxzpiXqJKUX4EUJOvxGrzIaNoN1QrKbRmnqUOOS+AkestlMKd0khiObWGtMChsMtvPNy+6Ef9ywgEYWr0gJBvhEgC3YuMO8MiJIlB3wDTdXZK/NhQODsSrBleboOQ1+JBY="
+      },
+      "windows-amd64": {
+        "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-zoom-v1.5.1-windows-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmFTTCQACgkQ0bVLR6XO/sQUuw/+PLuGuayGdCzPEAQ7m2yrLiRxYY+YaHNuFfG/Q8XwE4gLQk5cENZ8q5dAjmcQHLRxVfmnQGRhDUgEbYI1qIXcztEvFUKAwnyzRFtlCEc88aZKnBWYf0FNNJULCs3egsoG9bndl/IfYvSqyvcYh6/DXAOgo2FG7wU2iOw+mT6SMGB5z1bm3XrtoeR6uuwKc2BYyT38Fom3rmEQjc9eemnPaQ5HZRJbjUhLVcQm114c89sBK7QUJ4MU9xcs1kcPD1l6KtgV+6NwoL+tsUCVUVgNQWfzUyLPOLaFwNUrBX/IpHCHvvq2rrSJvrEmrmdhyHBNwb16MCfA+RC7XkdsyRurhhm7vrrC/SjIEhDvvJwwHULbtv+lfp+whJLG3acizjJLzbtMua6uRo0PrBmWRoLHXT1h1h+VS7TAjAG9eRgCpl0hlw4yiwgDmgBEG/6w4huU12iJC0u6po9DW3XvcBXagFRQHboaPkZtLdHOomi/y9L/Vu6c0oZ0YMPr0HHbVFsQ4bwC1k2ExlpK6gNGis8NAkhkqMkEMbq1I5Z44BNaefZhjJWn/2C6Tf2ki+7PEEnQh4RfQGRJJELXJT1cxKApxE7V3izHa/WSehY0ibI33+vZFCvqHMeIdbBnwbm0KFfjepXTMRJxKYUlS2Cv8uMC294vNeBfrarXY261f/7qhzw="
+      }
+    },
+    "updated_at": "2022-06-06T11:01:53.813242176Z"
+  },
+  {
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-zoom",
+    "icon_data": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iOTEyIiBoZWlnaHQ9IjkxMiIgdmlld0JveD0iMCAwIDkxMiA5MTIiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxjaXJjbGUgY3g9IjQ1NiIgY3k9IjQ1NiIgcj0iNDU2IiBmaWxsPSIjMkQ4Q0ZGIi8+CjxwYXRoIGQ9Ik0xOTkuNSAzNDkuMTI1QzE5OS41IDMzMy4zODUgMjEyLjI2IDMyMC42MjUgMjI4IDMyMC42MjVINDcwLjI1QzUyOS4yNzUgMzIwLjYyNSA1NzcuMTI1IDM2OC40NzUgNTc3LjEyNSA0MjcuNVY1NjIuODc1QzU3Ny4xMjUgNTc4LjYxNSA1NjQuMzY1IDU5MS4zNzUgNTQ4LjYyNSA1OTEuMzc1SDMwNi4zNzVDMjQ3LjM1IDU5MS4zNzUgMTk5LjUgNTQzLjUyNSAxOTkuNSA0ODQuNVYzNDkuMTI1WiIgZmlsbD0id2hpdGUiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik02NzYuODE1IDU4My44MjlMNjE4LjI5MyA1MzguNjUzQzYxNC43OTcgNTM1Ljk1NSA2MTIuNzUgNTMxLjc4OSA2MTIuNzUgNTI3LjM3M1Y0MTMuMTI3QzYxMi43NSA0MDguNzExIDYxNC43OTcgNDA0LjU0NSA2MTguMjkzIDQwMS44NDdMNjc2LjgxNSAzNTYuNjcxQzY4MS4zNDUgMzUyLjAxNiA2ODcuNjc5IDM0OS4xMjUgNjk0LjY4OCAzNDkuMTI1QzcwOC40NiAzNDkuMTI1IDcxOS42MjUgMzYwLjI5IDcxOS42MjUgMzc0LjA2MlY1NjYuNDM4QzcxOS42MjUgNTgwLjIxIDcwOC40NiA1OTEuMzc1IDY5NC42ODggNTkxLjM3NUM2ODcuNjc5IDU5MS4zNzUgNjgxLjM0NSA1ODguNDg0IDY3Ni44MTUgNTgzLjgyOVoiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPgo=",
     "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-zoom-v1.5.1-cloud.tar.gz",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-zoom/releases/tag/v1.5.1",
     "hosting": "cloud",


### PR DESCRIPTION
#### Summary
Generated with `go run ./cmd/generator/ add mattermost-plugin-zoom v1.6.0 --official --on-prem`.

Changelist at https://github.com/mattermost/mattermost-plugin-zoom/releases/tag/v1.6.0.

#### Ticket Link
--

