### PR TITLE
Add v0.6.1-alpha2 of mattermost-plugin-calls to the Marketplace

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -3303,6 +3303,109 @@
   {
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
     "icon_data": "",
+    "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.6.1-alpha2.tar.gz",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.6.1-alpha2",
+    "hosting": "cloud",
+    "author_type": "mattermost",
+    "release_stage": "beta",
+    "enterprise": false,
+    "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmKjXf8ACgkQ0bVLR6XO/sRTQA/+IquyPz5uXfTyrGiJVVitPy741yzbnvObgXL0tl0QznXd4S0slmIJxKHI1wCtAIdPJ8jxk01w3PStCOZbNdQNRky0pCUplwAUXMgjmPx54VhLpAbXzr3hpspoifuvfGvWzuZsLKdV/ZOu9E3Hn+QulnsKogoZboYOtmH/z9MpeNcBT9Eagv65WIbeurxLkryWpG2lr/WKffanJMRyG4ipE8P/CJs2NhiZ9b70zrncCrNJNT2+wvrD1ZR/6O+nn8ttWmyM5NM+dldaAhkSNO1QKud9Xb1QVwFGIfXPixanYOT4ItLxKhytZzL4sQYXaFN51CgVWG4y6BX0gMW/su/PyRjzY1y5StQL4uf28FOy+PXIQNEhHc778WyMBQvn6JZcrBgHr8hYhfTk/3jGdSKA+Fkt/RsTNg3J/aiVVbUYBvi16LFe0kWQtW++oKkplP8WXL8iKryL/z7Ty/WKZ1SC0epmnekZVvC+cHNup3tsA9sikp3sgpDkA2LCMXPNMwjqlaioCT8F7bErL7sxpqlE+ga8FimfDBzGYzIMzwqlCvmWK53XfrJiTdiSXMnB/p8Hv48TKJlrTTXKCVgyMPhFpQ5bi3HcOXscnT8G40uebAe5/acuM3Dqqxj56KVPdt4E7mdcQsx0lnRZ9EDQZm2mFeU9t33ynh/FH2Ywk6p4iKQ=",
+    "repo_name": "mattermost-plugin-calls",
+    "manifest": {
+      "id": "com.mattermost.calls",
+      "name": "Calls (Beta)",
+      "description": "Integrates real-time voice communication in Mattermost",
+      "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
+      "support_url": "https://github.com/mattermost/mattermost-plugin-calls/issues",
+      "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.6.1-alpha2",
+      "version": "0.6.1-alpha2",
+      "min_server_version": "6.6.0",
+      "server": {
+        "executables": {
+          "linux-amd64": "server/dist/plugin-linux-amd64",
+          "darwin-amd64": "server/dist/plugin-darwin-amd64"
+        },
+        "executable": ""
+      },
+      "webapp": {
+        "bundle_path": "webapp/dist/main.js"
+      },
+      "settings_schema": {
+        "header": "Calls plugin enables voice calls with screensharing in channels. See [documentation](https://docs.mattermost.com/channels/make-calls.html) to learn more.",
+        "footer": "",
+        "settings": [
+          {
+            "key": "UDPServerPort",
+            "display_name": "RTC Server Port",
+            "type": "number",
+            "help_text": "The UDP port the RTC server will listen on.",
+            "placeholder": "8443",
+            "default": 8443
+          },
+          {
+            "key": "AllowEnableCalls",
+            "display_name": "Enable on specific channels",
+            "type": "bool",
+            "help_text": "When set to true, Channel Admins can enable or disable calls in their channels. It also allows participants in DMs/GMs to enable or disable calls.",
+            "placeholder": "",
+            "default": false
+          },
+          {
+            "key": "DefaultEnabled",
+            "display_name": "Enable on all channels",
+            "type": "bool",
+            "help_text": "When set to true, calls can be started in all channels where they're not explicitly disabled.",
+            "placeholder": "",
+            "default": false
+          },
+          {
+            "key": "MaxCallParticipants",
+            "display_name": "Max call participants",
+            "type": "number",
+            "help_text": "The maximum number of participants that can join a call. If left empty, or set to 0, it means unlimited.",
+            "placeholder": "",
+            "default": 0
+          },
+          {
+            "key": "ICEHostOverride",
+            "display_name": "ICE Host Override",
+            "type": "text",
+            "help_text": "(Optional) The IP (or hostname) to be used as the host ICE candidate. If empty, it defaults to resolving via STUN.",
+            "placeholder": "",
+            "default": ""
+          },
+          {
+            "key": "ICEServers",
+            "display_name": "ICE Servers",
+            "type": "text",
+            "help_text": "(Optional) A comma-separated list of ICE servers' URLs (STUN/TURN) to use.",
+            "placeholder": "stun:example.com:3478",
+            "default": "stun:stun.global.calls.mattermost.com:3478"
+          },
+          {
+            "key": "RTCDServiceURL",
+            "display_name": "RTCD service URL",
+            "type": "text",
+            "help_text": "(Optional) The URL to a running RTCD service instance that should host the calls. When set (non empty) all calls will be handled by the external service.",
+            "placeholder": "https://rtcd.example.com",
+            "default": null
+          }
+        ]
+      }
+    },
+    "platforms": {
+      "linux-amd64": {
+        "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.6.1-alpha2-linux-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmKjXfwACgkQ0bVLR6XO/sTeIRAAhkoPt96TjdfFWDdlQA6QieaOvBMJOLZqjwOxXR6N55BFhVxJyz6eeJR6v89mf+k/hIXycklWYoKPEyG+Muv0DJopd4GkvFf+qvpH1nVIlHJqcfCcY02saJvMbhosxoVwkFY9zWtDfZylxkFM+Pla8KfeY8iuJNR+7Qwh3ZIGMpZ7q6Vmxqe9twSCO0CY0KZLpXpaV0Ya1K4LI1ULnPqxWSmGFDMkK0DaE69VmjMST+iy9uTJY/bNKaing/bfPx9yFjTW/vHjH5nCEWuBIP7Y0UwNL8AJY7HE7MdWXOGv6IOOJfmex2HJYEsZxiu5VJa9z2h6ZrUpa8Y3k5JIwGzi8/2dqPPKG7P6LdoOLUyURodn9suTxqqF8mi7PQA6BdcB46qfxshFGdiq+T9FYHV1ZHvhkcfulkqndxOIuPwndTTy3m/payZ/6tXAlHkt9QQCweMFfIR1RgiufURmd5U9KiHkPwd0rGAZJTaSk2MieLinrGTx8Qm1q3v1elzU+a7vR033xr/+7w3PLef9DwVfK0iFcrjHRDgZSeCHLEIm61ryViyiICoPHnCC/08Ba/XMavK2M0+ZbthpZsYI5YonvpHqBZYePoe/lXI/YwSb+h2uN9WAtN10TBByMt+VPDJMoDYa25EiY/HRmGwVwjNaPeUiuURcad0auAaEhuQe1Nc="
+      },
+      "darwin-amd64": {},
+      "windows-amd64": {}
+    },
+    "updated_at": "2022-06-10T15:33:37.100218Z"
+  },
+  {
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
+    "icon_data": "",
     "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.6.0.tar.gz",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.6.0",
     "hosting": "",


### PR DESCRIPTION
#### Summary
- This is for testing the cloud free trial changes in https://github.com/mattermost/mattermost-plugin-calls/pull/105 That's why it's `"hosting": "cloud"`
- Will be reverted as soon as testing is done

#### Ticket Link
- none
