### PR TITLE
MM-46421 - Add v0.8.1 of mattermost-plugin-calls to the Marketplace

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -3422,6 +3422,133 @@
   {
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
     "icon_data": "",
+    "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.8.1.tar.gz",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.8.1",
+    "hosting": "",
+    "author_type": "mattermost",
+    "release_stage": "beta",
+    "enterprise": false,
+    "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmMfYMgACgkQ0bVLR6XO/sT+Xw/8DUx0kEwdIgSg//8sswtw3ocGNoA6dtdpPxq6JDTGvKgIATAX77duHfBpZe2CF8/TLydx30mR/OM0jIiLLiMMycAFfLPDzrGavV+Z2LHr17AueLLFk/WA8O2Q4odfLAlSniZp7UhJ6eiS1UMd7jv1TgzFfmDFZ/TGuGhL1RGsENbN8UvOm6xyvjMq6kFBzrVp6jsV/qhnh8LqmwfsLiCuAA7yKqx671KLNcy56/U1gUCYV0o5FIjbOETzYNpaLGPkvKRNn3j2/LuWzpnBTHc7F3/SjNe80THojYKJ8i4GscLZST+qZIulSbtlsLY+t+ZA5TZJrR1BKFFvWUtecovueKrdk4M8hQG3SmHaxc3bSqlfE55V6tS5yppgyEtB/6y/WMkLmkTQ19Ub311RTEeFhrKve1+LHHVo9GW6zAwB+e6IFxJ1p2fJHH1buND539noje50+pyK0S1oO3+cs/FhlFCC5DAX6Je8RzkbOPESgVPIkXzoH9ohD5tuhQPxRBOEa65nTzzwaZjLMfz4cmp46Uw0JuqaGtxdE4Jld33+qfa09lt8R5gDUbz8JAhcUA6fdbeyOe5xweHCZsv/GKn2N4jgITXUUO/IGwQJcYPOZX1Vm531fTxLBjmKQB7g3xWNPdedpo5axX0p+4rCBZ1eOP2TXCP9iFPLkelujlu4XL4=",
+    "repo_name": "mattermost-plugin-calls",
+    "manifest": {
+      "id": "com.mattermost.calls",
+      "name": "Calls (Beta)",
+      "description": "Integrates real-time voice communication in Mattermost",
+      "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
+      "support_url": "https://github.com/mattermost/mattermost-plugin-calls/issues",
+      "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.8.1",
+      "version": "0.8.1",
+      "min_server_version": "6.6.0",
+      "server": {
+        "executables": {
+          "linux-amd64": "server/dist/plugin-linux-amd64",
+          "darwin-amd64": "server/dist/plugin-darwin-amd64"
+        },
+        "executable": ""
+      },
+      "webapp": {
+        "bundle_path": "webapp/dist/main.js"
+      },
+      "settings_schema": {
+        "header": "Calls plugin enables voice calls with screensharing in channels. See [documentation](https://docs.mattermost.com/channels/make-calls.html) to learn more.",
+        "footer": "",
+        "settings": [
+          {
+            "key": "UDPServerPort",
+            "display_name": "RTC Server Port",
+            "type": "number",
+            "help_text": "The UDP port the RTC server will listen on.",
+            "placeholder": "8443",
+            "default": 8443
+          },
+          {
+            "key": "AllowEnableCalls",
+            "display_name": "Enable on specific channels",
+            "type": "bool",
+            "help_text": "When set to true, Channel Admins can enable or disable calls in their channels. It also allows participants in DMs/GMs to enable or disable calls.",
+            "placeholder": "",
+            "default": false
+          },
+          {
+            "key": "DefaultEnabled",
+            "display_name": "Enable on all channels",
+            "type": "bool",
+            "help_text": "When set to true, calls can be started in all channels where they're not explicitly disabled.",
+            "placeholder": "",
+            "default": false
+          },
+          {
+            "key": "MaxCallParticipants",
+            "display_name": "Max call participants",
+            "type": "number",
+            "help_text": "The maximum number of participants that can join a call. If left empty, or set to 0, it means unlimited.",
+            "placeholder": "",
+            "default": 0
+          },
+          {
+            "key": "ICEHostOverride",
+            "display_name": "ICE Host Override",
+            "type": "text",
+            "help_text": "(Optional) The IP (or hostname) to be used as the host ICE candidate. If empty, it defaults to resolving via STUN.",
+            "placeholder": "",
+            "default": ""
+          },
+          {
+            "key": "ICEServersConfigs",
+            "display_name": "ICE Servers Configurations",
+            "type": "longtext",
+            "help_text": "(Optional) A list of ICE servers (STUN/TURN) configurations to use. This field should contain a valid JSON array.",
+            "placeholder": "[{\n \"urls\":[\"turn:turnserver.example.org:3478\"],\n \"username\": \"webrtc\",\n \"credential\": \"turnpassword\"\n}]",
+            "default": "[{\"urls\":[\"stun:stun.global.calls.mattermost.com:3478\"]}]"
+          },
+          {
+            "key": "TURNStaticAuthSecret",
+            "display_name": "TURN Static Auth Secret",
+            "type": "text",
+            "help_text": "(Optional) The secret key used to generate TURN short-lived authentication credentials.",
+            "placeholder": "",
+            "default": ""
+          },
+          {
+            "key": "TURNCredentialsExpirationMinutes",
+            "display_name": "TURN Credentials Expiration (minutes)",
+            "type": "number",
+            "help_text": "(Optional) The number of minutes that the generated TURN credentials will be valid for.",
+            "placeholder": "",
+            "default": 1440
+          },
+          {
+            "key": "ServerSideTURN",
+            "display_name": "Server Side TURN",
+            "type": "bool",
+            "help_text": "(Optional) When set to true it will pass and use configured TURN candidates to server initiated connections.",
+            "placeholder": "",
+            "default": false
+          },
+          {
+            "key": "RTCDServiceURL",
+            "display_name": "RTCD service URL",
+            "type": "text",
+            "help_text": "(Optional) The URL to a running RTCD service instance that should host the calls. When set (non empty) all calls will be handled by the external service.",
+            "placeholder": "https://rtcd.example.com",
+            "default": null
+          }
+        ]
+      }
+    },
+    "platforms": {
+      "linux-amd64": {
+        "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.8.1-linux-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmMfYMUACgkQ0bVLR6XO/sTJqw/9GgOdATVdWPCN5j6qldsfDUM/Y5rJRjxUkXRcruAOK1Hm1CmRkzM0+8+b3s9a52u5EFWTUI+/LuVCDG68UUe6sa56Q7z+Nzv1G3Y2rT6PKnJyA+IHPVC+DzG755h81Gbbfef4Y8fweTnipJ465RohDHBs312xBIOuJUoU0/3csJbN2JMLY6iDFxeby3gbRoDFbyWN8FXyF2f6Bhbod/g4w5uqnDXkpSpm/Ys7NFliZFE8k32EFBJ8Ka0Z9IxGSdfb79liv0jj7eSOXT75XJ4wHpxfFok6ge5lPuR/rJ1YnlmXLydnENOZDB/e5eaOG+5D2Y9MFJ7gyH9PSJSp1swIRPuIRjH4/wjO2XjOUFf5xny7fx9eiHRPvqf/iN9IDlI2Oowv1y05/woI8PHFTthE6b85mfNKN1BwjRk48bV8rqk7ywpYcDx6LSjdHCK8CIf8ygrepsxXeaHQx0q3dlZk8InzPNUjAQCCn4v1Bqh4zl+vjUbYErVspUVnSIIg0DHqIZhsrRei4MAqPzSTny8IZut10ViU6gqjxtnW35aP/u6gb38pYFLHmt033dHWtFUc/D93m4Too3vTXchiVx6eD83hiwRcwqfMXZXAIMUysEdPxdNo1eAqG7eFLeGLitPUvg/if6a20nVcpJNDsVKGd4BviMMLDwvXOt6VNaXB+L0="
+      },
+      "darwin-amd64": {},
+      "windows-amd64": {}
+    },
+    "updated_at": "2022-09-12T16:40:37.041399Z"
+  },
+  {
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
+    "icon_data": "",
     "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.7.1.tar.gz",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.7.1",
     "hosting": "",


### PR DESCRIPTION
#### Summary
- cut with `/mb cutplugin --repo mattermost-plugin-calls --tag v0.8.1 --pre-release`
- this commit made with `go run ./cmd/generator/ add mattermost-plugin-calls v0.8.1 --official --beta`

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-46421