### PR TITLE
MM-47037 - Add mattermost plugin calls v0.9.0 to the marketplace

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -3541,6 +3541,133 @@
   {
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
     "icon_data": "",
+    "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.9.0.tar.gz",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.9.0",
+    "hosting": "",
+    "author_type": "mattermost",
+    "release_stage": "beta",
+    "enterprise": false,
+    "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmM/HowACgkQ0bVLR6XO/sRQvg/9E5tNr/4axldbbk29dXRqtinv7LoUxB2/YKxpwZPFI1eE+qK0sAvIULmwg+pCNdo9+FLeIEX4jciyUH8jPdRLwE9QTWwMTtU0OzjHnd+0wbrtqDcm+pQalexb0kqNN6pp8lK0+0RHm33cNCiVHlAP85+IGyJi57aqap5Hem6aQJhT/p65H6OrIEwwSTvi4MNCMKpw5e9pCWmDRtFIGmdwpxw178/qTRDICmfiGQxcnmuOHmpMr8c6Y3tyzu8dqwEOQHFuDcIYVFOIuym1E8txZmwEZEG2/quW96lVIy8u7Tes6O4yJkMgtjgezlPTEMLixhVnerz1xOjtCjdzS2kDBpvRtB9F1NXvK7Q9s9+bbOjR3fkpN4PGZVBeGD7sGb/uKEToTRhL6Pqy7B3TiZL6jsqf6qJfxJMhEwYYfNth4Vg3S+ah//QyurpiYTjSiB3pVekRSOMFfiHA4I7XsHhKh4gpURwoCkQZHUjp8wHHNJA4K2M2Qq5d0oWgdAy1uSLHsr5CwxZnHUW8EVzpsCXoj62fnJCIKLFOuGK9edW8ADvrkqAGekyDHqc8Eey+Hb/KzL/S/s2ev4AiyAhwg5vyZIqSxXH6a+FTQofdaC52DK/gRXOf7kywjU8Aa6SxFimo+wfGOmhlpo7plwECFA+qKbMN7TFE0Sy/sAUKjlbjBCY=",
+    "repo_name": "mattermost-plugin-calls",
+    "manifest": {
+      "id": "com.mattermost.calls",
+      "name": "Calls (Beta)",
+      "description": "Integrates real-time voice communication in Mattermost",
+      "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
+      "support_url": "https://github.com/mattermost/mattermost-plugin-calls/issues",
+      "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.9.0",
+      "version": "0.9.0",
+      "min_server_version": "6.6.0",
+      "server": {
+        "executables": {
+          "linux-amd64": "server/dist/plugin-linux-amd64",
+          "darwin-amd64": "server/dist/plugin-darwin-amd64"
+        },
+        "executable": ""
+      },
+      "webapp": {
+        "bundle_path": "webapp/dist/main.js"
+      },
+      "settings_schema": {
+        "header": "Calls plugin enables voice calls with screensharing in channels. See [documentation](https://docs.mattermost.com/channels/make-calls.html) to learn more.",
+        "footer": "",
+        "settings": [
+          {
+            "key": "UDPServerPort",
+            "display_name": "RTC Server Port",
+            "type": "number",
+            "help_text": "The UDP port the RTC server will listen on.",
+            "placeholder": "8443",
+            "default": 8443
+          },
+          {
+            "key": "AllowEnableCalls",
+            "display_name": "Enable on specific channels",
+            "type": "bool",
+            "help_text": "When set to true, Channel Admins can enable or disable calls in their channels. It also allows participants in DMs/GMs to enable or disable calls.",
+            "placeholder": "",
+            "default": false
+          },
+          {
+            "key": "DefaultEnabled",
+            "display_name": "Enable on all channels",
+            "type": "bool",
+            "help_text": "When set to true, calls can be started in all channels where they're not explicitly disabled.",
+            "placeholder": "",
+            "default": false
+          },
+          {
+            "key": "MaxCallParticipants",
+            "display_name": "Max call participants",
+            "type": "number",
+            "help_text": "The maximum number of participants that can join a call. If left empty, or set to 0, it means unlimited.",
+            "placeholder": "",
+            "default": 0
+          },
+          {
+            "key": "ICEHostOverride",
+            "display_name": "ICE Host Override",
+            "type": "text",
+            "help_text": "(Optional) The IP (or hostname) to be used as the host ICE candidate. If empty, it defaults to resolving via STUN.",
+            "placeholder": "",
+            "default": ""
+          },
+          {
+            "key": "ICEServersConfigs",
+            "display_name": "ICE Servers Configurations",
+            "type": "longtext",
+            "help_text": "(Optional) A list of ICE servers (STUN/TURN) configurations to use. This field should contain a valid JSON array.",
+            "placeholder": "[{\n \"urls\":[\"turn:turnserver.example.org:3478\"],\n \"username\": \"webrtc\",\n \"credential\": \"turnpassword\"\n}]",
+            "default": "[{\"urls\":[\"stun:stun.global.calls.mattermost.com:3478\"]}]"
+          },
+          {
+            "key": "TURNStaticAuthSecret",
+            "display_name": "TURN Static Auth Secret",
+            "type": "text",
+            "help_text": "(Optional) The secret key used to generate TURN short-lived authentication credentials.",
+            "placeholder": "",
+            "default": ""
+          },
+          {
+            "key": "TURNCredentialsExpirationMinutes",
+            "display_name": "TURN Credentials Expiration (minutes)",
+            "type": "number",
+            "help_text": "(Optional) The number of minutes that the generated TURN credentials will be valid for.",
+            "placeholder": "",
+            "default": 1440
+          },
+          {
+            "key": "ServerSideTURN",
+            "display_name": "Server Side TURN",
+            "type": "bool",
+            "help_text": "(Optional) When set to true it will pass and use configured TURN candidates to server initiated connections.",
+            "placeholder": "",
+            "default": false
+          },
+          {
+            "key": "RTCDServiceURL",
+            "display_name": "RTCD service URL",
+            "type": "text",
+            "help_text": "(Optional) The URL to a running RTCD service instance that should host the calls. When set (non empty) all calls will be handled by the external service.",
+            "placeholder": "https://rtcd.example.com",
+            "default": null
+          }
+        ]
+      }
+    },
+    "platforms": {
+      "linux-amd64": {
+        "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.9.0-linux-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmM/HogACgkQ0bVLR6XO/sTxnw//ZG0tCseYOUUnQJUe6gI46n5dcZbrnc9Xq71FHHhZR9oADqdbpMi2RfrdrsGy8IVmY4jKwEMQTFYxV/6PWNrAFJF2Vl33/tmEVABPvZsh5wTouXY1MS+tOWUA72URrbzpy4MSP7JZ8gzMXWnWVe5oAr3xMCx+fqEkImInI+zoMhP5YsYr9c7rcoobukICMDTaVdNaXKpxCl+bGgCW/R+RES+IvdNEXUTTJEuZwHcO8L/aWASwPWi53ZY0LcmZnb8BnhJTfsSPj/6jwaSdwYizm8iOSgyEn1ki9B7p++s4tCl1UcfvjjaLdFnoZIzP43fDuNDQfhP7hFBXIuCmWwBFriShY2iMtFtqn7w+rltwvxsKo4znhAGi+6DcqeEPYSC0YP8IpHa9FXFOU1Fei+gjcoIqRn3dXfSPr53lNO7ue01HrHq8ibIubZaxao5J544WxXWPVtoR04wjAcDW+fguLVqkdH2JEcYg75oMqUfPPEDX/55F6+oCTlPy22qMFo1GWsp0IR+f16LchsfNWE3oRohSTaT2TvsCq7dsZSTAFkLrmWoxohUqVwNEzhPq0GYofZIijyQ8y2pYHMC71S+jEojttLurGbB6qrArf2knW5CDP4yhXTvDdeWws9wbYmt6ebOBhONQ5Ieo+vPUGGS9OI4+wnJp96oTxFYrED5Dl/8="
+      },
+      "darwin-amd64": {},
+      "windows-amd64": {}
+    },
+    "updated_at": "2022-10-06T18:31:03.599532Z"
+  },
+  {
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
+    "icon_data": "",
     "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.8.1.tar.gz",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.8.1",
     "hosting": "",


### PR DESCRIPTION
#### Summary
- cut with `/mb cutplugin --repo mattermost-plugin-calls --tag v0.9.0`
- this commit made with `go run ./cmd/generator/ add mattermost-plugin-calls v0.9.0 --official --beta`

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-46421