### PR TITLE
MM-49638 - Add v0.12.1 of mattermost-plugin-calls to the Marketplace

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -3785,6 +3785,177 @@
   {
       "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
       "icon_data": "",
+      "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.12.1.tar.gz",
+      "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.12.1",
+      "hosting": "",
+      "author_type": "mattermost",
+      "release_stage": "production",
+      "enterprise": false,
+      "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmPAd94ACgkQ0bVLR6XO/sRRJQ/9HR04IVavRTf6U05Oa168RSEuCevxOzd4KetCe18MS2t2w3SO9BV5vIdI4fJgI2yh1OJ6dF1FdhF+uYqfoXee8OEpv7NHqVemOPGst/QzvIGf/trV4aZCa19iE7Kjp0OdA2+w/wDScccIzh6asVW2mAgyIuVIQfuirYZQUxtDbQ61JAfEbIwmdEPn3fRztUoB2kRs2718J+WM6oTACh4KMthZRB9bq4yjEPzWKlMvGhRvQLRd/NhhS0dkuTslF8ssO4zFgYd/J2LMwoWHohUGKwpL9eHhZzKk1VkDg6OpYFVqM4jkTNDTbhq8EcTRNk17kbFb6A/VHyaySOnKyS5mpvGV8qIsrJD9AozngcKplUQNMn+ntdGEZm8EbtHyQA5vfCaMSg7dUom+VFlFiN0lX2O8Nip+xZ74aD9knfsXgMxpAeJDcV95gp9Ag9XAmElJF0biEBJPmzx2cvhm3i8DtXtKukrf3RDKh2kkv3xjzBCqZH7f2+FMftugjB5PWKkxrLj5CtJIyNSpgLOlYSFrz3trxcGdCcjITB2OogLquo0ni92TTiubIlWuYNmgXsRN0J9xAAU3OjbkaPiWDUWd+nBNEUubgOUhqAFGKAAtCFYlmeSfETlVZZRqak1UuCBaf3imFQZgCzuFZEaUfaez/HtRR9JfC0cWJ7eRFL1CDeU=",
+      "repo_name": "mattermost-plugin-calls",
+      "manifest": {
+          "id": "com.mattermost.calls",
+          "name": "Calls",
+          "description": "Integrates real-time voice communication in Mattermost",
+          "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
+          "support_url": "https://github.com/mattermost/mattermost-plugin-calls/issues",
+          "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.12.1",
+          "version": "0.12.1",
+          "min_server_version": "7.6.0",
+          "server": {
+              "executables": {
+                  "darwin-amd64": "server/dist/plugin-darwin-amd64",
+                  "darwin-arm64": "server/dist/plugin-darwin-arm64",
+                  "freebsd-amd64": "server/dist/plugin-freebsd-amd64",
+                  "linux-amd64": "server/dist/plugin-linux-amd64",
+                  "linux-arm64": "server/dist/plugin-linux-arm64",
+                  "openbsd-amd64": "server/dist/plugin-openbsd-amd64"
+              },
+              "executable": ""
+          },
+          "webapp": {
+              "bundle_path": "webapp/dist/main.js"
+          },
+          "settings_schema": {
+              "header": "Calls plugin enables voice calls with screensharing in channels. See [documentation](https://docs.mattermost.com/channels/make-calls.html) to learn more.",
+              "footer": "",
+              "settings": [
+                  {
+                      "key": "DefaultEnabled",
+                      "display_name": "Test mode",
+                      "type": "custom",
+                      "help_text": "When test mode is enabled, only system admins are able to start calls in channels. This allows testing to confirm calls are working as expected.",
+                      "placeholder": "",
+                      "default": null,
+                      "hosting": "on-prem"
+                  },
+                  {
+                      "key": "UDPServerPort",
+                      "display_name": "RTC Server Port",
+                      "type": "number",
+                      "help_text": "The UDP port the RTC server will listen on.",
+                      "placeholder": "8443",
+                      "default": 8443,
+                      "hosting": "on-prem"
+                  },
+                  {
+                      "key": "MaxCallParticipants",
+                      "display_name": "Max call participants",
+                      "type": "number",
+                      "help_text": "The maximum number of participants that can join a call. If left empty, or set to 0, it means unlimited.",
+                      "placeholder": "",
+                      "default": 0,
+                      "hosting": "on-prem"
+                  },
+                  {
+                      "key": "ICEHostOverride",
+                      "display_name": "ICE Host Override",
+                      "type": "text",
+                      "help_text": "(Optional) The IP (or hostname) to be used as the host ICE candidate. If empty, it defaults to resolving via STUN.",
+                      "placeholder": "",
+                      "default": "",
+                      "hosting": "on-prem"
+                  },
+                  {
+                      "key": "ICEServersConfigs",
+                      "display_name": "ICE Servers Configurations",
+                      "type": "longtext",
+                      "help_text": "(Optional) A list of ICE servers (STUN/TURN) configurations to use. This field should contain a valid JSON array.",
+                      "placeholder": "[{\n \"urls\":[\"turn:turnserver.example.org:3478\"],\n \"username\": \"webrtc\",\n \"credential\": \"turnpassword\"\n}]",
+                      "default": "[{\"urls\":[\"stun:stun.global.calls.mattermost.com:3478\"]}]",
+                      "hosting": "on-prem"
+                  },
+                  {
+                      "key": "TURNStaticAuthSecret",
+                      "display_name": "TURN Static Auth Secret",
+                      "type": "text",
+                      "help_text": "(Optional) The secret key used to generate TURN short-lived authentication credentials.",
+                      "placeholder": "",
+                      "default": "",
+                      "hosting": "on-prem"
+                  },
+                  {
+                      "key": "TURNCredentialsExpirationMinutes",
+                      "display_name": "TURN Credentials Expiration (minutes)",
+                      "type": "number",
+                      "help_text": "(Optional) The number of minutes that the generated TURN credentials will be valid for.",
+                      "placeholder": "",
+                      "default": 1440,
+                      "hosting": "on-prem"
+                  },
+                  {
+                      "key": "ServerSideTURN",
+                      "display_name": "Server Side TURN",
+                      "type": "bool",
+                      "help_text": "(Optional) When set to true it will pass and use configured TURN candidates to server initiated connections.",
+                      "placeholder": "",
+                      "default": false,
+                      "hosting": "on-prem"
+                  },
+                  {
+                      "key": "AllowScreenSharing",
+                      "display_name": "Allow screen sharing",
+                      "type": "bool",
+                      "help_text": "When set to true it allows call participants to share their screen.",
+                      "placeholder": "",
+                      "default": true,
+                      "hosting": ""
+                  },
+                  {
+                      "key": "RTCDServiceURL",
+                      "display_name": "RTCD service URL",
+                      "type": "text",
+                      "help_text": "(Optional) The URL to a running RTCD service instance that should host the calls. When set (non empty) all calls will be handled by the external service.",
+                      "placeholder": "https://rtcd.example.com",
+                      "default": null,
+                      "hosting": "on-prem"
+                  },
+                  {
+                      "key": "EnableRecordings",
+                      "display_name": "Enable call recordings (Beta)",
+                      "type": "bool",
+                      "help_text": "(Optional) When set to true it enables the call recordings functionality.",
+                      "placeholder": "",
+                      "default": false,
+                      "hosting": ""
+                  },
+                  {
+                      "key": "JobServiceURL",
+                      "display_name": "Job service URL",
+                      "type": "text",
+                      "help_text": "The URL to a running calls job service instance used for call recordings.",
+                      "placeholder": "https://calls-job-service.example.com",
+                      "default": null,
+                      "hosting": ""
+                  },
+                  {
+                      "key": "MaxRecordingDuration",
+                      "display_name": "Maximum call recording duration",
+                      "type": "number",
+                      "help_text": "The maximum duration (in minutes) for call recordings. Value must be in the range [15, 180].",
+                      "placeholder": "",
+                      "default": 60,
+                      "hosting": ""
+                  }
+              ]
+          },
+          "props": {
+              "min_rtcd_version": "v0.8.0"
+          }
+      },
+      "platforms": {
+          "linux-amd64": {
+              "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.12.1-linux-amd64.tar.gz",
+              "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmPAd9oACgkQ0bVLR6XO/sRzQg/9GlSvx121XVbpDBGpa9FXq3Xv4/VB1nz/7Njry6ldta3RiWocibRHCLbwzJGDcGKbhg/6XMyj7zAAeV5gfViwuKMHjbwlqNDrelLvSDeaOY0wM5DnOt96DzMELaIUFjd8I1guibmB/migFOL4lZCe1LtlIcg5URd1D6NLnYqUGlSHsR1hKSZ1CQsS1unvFZCkE0RnqgEjS8lonYoZw/RGLE85BpZwubOnOVxyv9qpRHe6bScnJAocZsktsnVzUpnXWxI9LOFH7wVAaC8xIQNWOVHSuUb+EvXvSsAFOkczCYk0A6YN/0WlfmnEJAPwzgjbXKbkQ4dubkT6z0pXnG+4IE475tQzOjKcoUwo9W/i0jEhTEVuLx3nO/strYlvtyO2ntANOM3aYGLWbTjw2CJMRcYPM/oKCB7mV7swNz2BIgh57TCTkhD33xL49JA22PZGoA8J3LbyUNW+iOHhSe61afPTSZ4r9/WcAmYFmUmz7ow6FsmSMgCuwpGwsDSqE0MtGsGgoPa3rKUj5xJjBrwm70a2l8oZXq2DrmRIv/JAIl6VlVR4eWYa/EnCBzYK3Q9yEmXcwmNmHGrCIINcxRbkOefdDth+7wDZGJTsybbkKHMnTixvHzHrLZZ1UqpQk3udOB2zpBtDXkpxDaGAMUwJBPOxI6KqbjKFpzVWOSh9iBM="
+          },
+          "darwin-amd64": {},
+          "windows-amd64": {}
+      },
+      "updated_at": "2023-01-12T21:30:15.903739Z"
+  },
+  {
+      "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
+      "icon_data": "",
       "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.12.0.tar.gz",
       "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.12.0",
       "hosting": "",


### PR DESCRIPTION
#### Summary
- NOTE: I had to do this kind of manually, again (see #332 and #333 )

- cut with `/mb cutplugin --repo mattermost-plugin-calls --tag v0.12.1`
- this commit made with `go run ./cmd/generator/ add mattermost-plugin-calls v0.12.1 --official`

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-49638