### PR TITLE
[MM-50329] Allow adding plugins with an invalid manifest to the Marketplace

### DIFF
--- a/cmd/generator/add.go
+++ b/cmd/generator/add.go
@@ -10,6 +10,7 @@ import (
 	"github.com/blang/semver"
 	mattermostModel "github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/mattermost/mattermost-marketplace/internal/model"
@@ -136,7 +137,10 @@ var addCmd = &cobra.Command{
 
 		err = manifest.IsValid()
 		if err != nil {
-			return errors.Wrap(err, "manifest is invalid")
+			logger.WithFields(logrus.Fields{
+				"id":      manifest.Id,
+				"version": manifest.Version,
+			}).Warn("Plugin manifest is invalid. Double check that the plugin correctly works.")
 		}
 
 		var iconData string

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -331,7 +331,10 @@ func getReleasePlugin(release *github.RepositoryRelease, repository *github.Repo
 
 		err = plugin.Manifest.IsValid()
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid manifest for release %s", releaseName)
+			logger.WithFields(logrus.Fields{
+				"id":      manifest.Id,
+				"version": manifest.Version,
+			}).Warn("Plugin manifest is invalid. Double check that the plugin correctly works.")
 		}
 
 		if plugin.Manifest.IconPath != "" {

--- a/internal/store/static.go
+++ b/internal/store/static.go
@@ -32,7 +32,7 @@ func NewStaticFromReader(reader io.Reader, logger logrus.FieldLogger) (*StaticSt
 
 // NewStatic constructs a new instance of a static store using the given plugins.
 func NewStatic(plugins []*model.Plugin, logger logrus.FieldLogger) (*StaticStore, error) {
-	if err := validatePlugins(plugins); err != nil {
+	if err := validatePlugins(plugins, logger); err != nil {
 		return nil, errors.Wrap(err, "failed to validate plugins")
 	}
 
@@ -42,11 +42,14 @@ func NewStatic(plugins []*model.Plugin, logger logrus.FieldLogger) (*StaticStore
 	}, nil
 }
 
-func validatePlugins(plugins []*model.Plugin) error {
+func validatePlugins(plugins []*model.Plugin, logger logrus.FieldLogger) error {
 	for _, plugin := range plugins {
 		err := plugin.Manifest.IsValid()
 		if err != nil {
-			return errors.Wrapf(err, "invalid manifest for plugin %s", plugin.Manifest.Id)
+			logger.WithFields(logrus.Fields{
+				"id":      plugin.Manifest.Id,
+				"version": plugin.Manifest.Version,
+			}).Warn("Plugin manifest is invalid. Double check that the plugin correctly works.")
 		}
 
 		if plugin.Manifest.Version == "" {


### PR DESCRIPTION
#### Summary
A plugin that makes use of an update in the manifest struct in the server will cause issues if it is added to the Marketplace as the Marketplace code is unaware of the struct update. https://github.com/mattermost/mattermost-marketplace/pull/332  is an example of that.

Allow the plugins with an invalid manifest in the Marketplace, but warn about them.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50329