### PR TITLE
Downgrade node version to 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       - image: cimg/go:1.19
   deploy:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:12
 
 references:
   workspace_root: &workspace_root
@@ -53,7 +53,7 @@ jobs:
       - *attach_workspace
       - run:
           name: Install Serverless CLI and dependencies
-          command: sudo npm i -g serverless@3
+          command: sudo npm i -g serverless@"<2.0.0"
       - run:
           name: Deploy Function
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,10 +61,6 @@ jobs:
                 export AWS_ACCESS_KEY_ID=$AWS_STAGING_ACCESS_KEY_ID
                 export AWS_SECRET_ACCESS_KEY=$AWS_STAGING_SECRET_ACCESS_KEY
                 sudo -E serverless deploy function -f server --stage staging
-            elif [ "${CIRCLE_BRANCH}" == "MM-50203_downgrade-node" ]; then
-                export AWS_ACCESS_KEY_ID=$AWS_STAGING_ACCESS_KEY_ID
-                export AWS_SECRET_ACCESS_KEY=$AWS_STAGING_SECRET_ACCESS_KEY
-                sudo -E serverless deploy function -f server --stage staging
             elif [ "${CIRCLE_BRANCH}" == "production" ]; then
                 export AWS_ACCESS_KEY_ID=$AWS_PRODUCTION_ACCESS_KEY_ID
                 export AWS_SECRET_ACCESS_KEY=$AWS_PRODUCTION_SECRET_ACCESS_KEY
@@ -88,4 +84,3 @@ workflows:
               only:
                 - master
                 - production
-                - MM-50203_downgrade-node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,10 @@ jobs:
                 export AWS_ACCESS_KEY_ID=$AWS_STAGING_ACCESS_KEY_ID
                 export AWS_SECRET_ACCESS_KEY=$AWS_STAGING_SECRET_ACCESS_KEY
                 sudo -E serverless deploy function -f server --stage staging
+            elif [ "${CIRCLE_BRANCH}" == "MM-50203_downgrade-node" ]; then
+                export AWS_ACCESS_KEY_ID=$AWS_STAGING_ACCESS_KEY_ID
+                export AWS_SECRET_ACCESS_KEY=$AWS_STAGING_SECRET_ACCESS_KEY
+                sudo -E serverless deploy function -f server --stage staging
             elif [ "${CIRCLE_BRANCH}" == "production" ]; then
                 export AWS_ACCESS_KEY_ID=$AWS_PRODUCTION_ACCESS_KEY_ID
                 export AWS_SECRET_ACCESS_KEY=$AWS_PRODUCTION_SECRET_ACCESS_KEY
@@ -84,3 +88,4 @@ workflows:
               only:
                 - master
                 - production
+                - MM-50203_downgrade-node


### PR DESCRIPTION
#### Summary
By using Node 12 serverless@"<2.0.0" can be installed again.

Please note the successful CI test run in https://github.com/mattermost/mattermost-marketplace/commit/a33ddb4f217bbd65708c3f93973f24c65f2cb31f.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-50203

