### PR TITLE
Always pull tags from master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export GO111MODULE=on
 
-BUILD_TAG = $(shell git describe --abbrev=0)
+BUILD_TAG = $(shell git describe --abbrev=0 master)
 BUILD_HASH = $(shell git rev-parse HEAD)
 BUILD_HASH_SHORT = $(shell git rev-parse --short HEAD)
 LDFLAGS += -X "github.com/mattermost/mattermost-marketplace/internal/api.buildTag=$(BUILD_TAG)"

--- a/internal/api/health_check_test.go
+++ b/internal/api/health_check_test.go
@@ -34,7 +34,7 @@ func TestHealthCheck(t *testing.T) {
 
 	assert.Equal(t, respose.Status, "pass")
 	assert.Equal(t, respose.Version, "1")
-	assert.Equal(t, respose.ReleaseID, "") // This needs to be changed, when the first tag is cut
+	assert.NotEmpty(t, respose.ReleaseID)
 	require.Len(t, respose.Details, 1)
 	require.Len(t, respose.Details["buildInfo"], 2)
 	assert.NotEmpty(t, respose.Details["buildInfo"]["buildHash"])


### PR DESCRIPTION
#### Summary
`git describe` tries to find a tag on the current branch. Tags are created on `master`. Given that `master` and `production` are distinct branches, the command needs to look at `master` instead of the current branch.

#### Ticket Link
None