### PR TITLE
MM-50566 - Add mattermost plugin calls v0.14.0

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -4088,6 +4088,187 @@
   {
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
     "icon_data": "",
+    "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.14.0.tar.gz",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.14.0",
+    "hosting": "",
+    "author_type": "mattermost",
+    "release_stage": "production",
+    "enterprise": false,
+    "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmQJJXgACgkQ0bVLR6XO/sSaKQ/9El5Ww2F9HSvm0Z2u5T+0FZjcN8zwXmQGPX6QpfDfW2m88jmozyEK7GyXJBuoUJ6CGkKjA5vmfeTpZhMDMyaszHHdvrWbREjoquJUzZgejCQbBAO9Xzoy47SDWPSJ6/pG7kBSRLiGHR7oMpLrMqhAmGMAvrZONieVsnIEr6aFUtpXm/ItCAlWc7AwgsgkffbvD0cA1bkKlETYPzkW81pOq8L02PiiMdddFXVwmy/D2iJXXlYtQ+6pchURJmiYBglCO0JsXo0oEHF+VYKIHLRT2UhTywiOSBMzDfN3A6tz9PXKEwnwYXKf4ydEPYzjXimbhgabThDsPGAYa/bP+4MY39oV1dmC+1tsrKMCLOMW+haRbuCNI2+5ObBzNiPY1MadzZrnZXCAPzpeSSHywk76rekqi1TXsBeLknGmwEkEKDdOsp9AQq5pifyuGjZ9sFHr9d35Oo4xjtFAIejqd9cx3a4fWKh/qhLTWt2ImG6Gf/rk5psHO+vKoS67c0Iag2ecQRrHYEEhsTHzlfwM8jy5CBIRqjLnodyGZrm8ho+Sxbyq+Mqst7xZTIUt3x3oG0c71ed3iRimVz5Om6n8Rs1Nycpymq9IVitOUKXV5GX3Eyhot4KTMaHWozaNBxhwX4hDERKhMA/nougvVQQ/3vN953pTVWoz0dFFb5eVqN1trWg=",
+    "repo_name": "mattermost-plugin-calls",
+    "manifest": {
+      "id": "com.mattermost.calls",
+      "name": "Calls",
+      "description": "Integrates real-time voice communication in Mattermost",
+      "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
+      "support_url": "https://github.com/mattermost/mattermost-plugin-calls/issues",
+      "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.14.0",
+      "version": "0.14.0",
+      "min_server_version": "7.6.0",
+      "server": {
+        "executables": {
+          "darwin-amd64": "server/dist/plugin-darwin-amd64",
+          "darwin-arm64": "server/dist/plugin-darwin-arm64",
+          "freebsd-amd64": "server/dist/plugin-freebsd-amd64",
+          "linux-amd64": "server/dist/plugin-linux-amd64",
+          "linux-arm64": "server/dist/plugin-linux-arm64",
+          "openbsd-amd64": "server/dist/plugin-openbsd-amd64"
+        },
+        "executable": ""
+      },
+      "webapp": {
+        "bundle_path": "webapp/dist/main.js"
+      },
+      "settings_schema": {
+        "header": "Calls plugin enables voice calls with screensharing in channels. See [documentation](https://docs.mattermost.com/channels/make-calls.html) to learn more.",
+        "footer": "",
+        "settings": [
+          {
+            "key": "DefaultEnabled",
+            "display_name": "Test mode",
+            "type": "custom",
+            "help_text": "When test mode is enabled, only system admins are able to start calls in channels. This allows testing to confirm calls are working as expected.",
+            "placeholder": "",
+            "default": null,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "UDPServerAddress",
+            "display_name": "RTC Server Address",
+            "type": "text",
+            "help_text": "The IP address used by the RTC server to listen on.",
+            "placeholder": "127.0.0.1",
+            "default": "",
+            "hosting": "on-prem"
+          },
+          {
+            "key": "UDPServerPort",
+            "display_name": "RTC Server Port",
+            "type": "number",
+            "help_text": "The UDP port the RTC server will listen on.",
+            "placeholder": "8443",
+            "default": 8443,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "MaxCallParticipants",
+            "display_name": "Max call participants",
+            "type": "number",
+            "help_text": "The maximum number of participants that can join a call. If left empty, or set to 0, it means unlimited.",
+            "placeholder": "",
+            "default": 0,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "ICEHostOverride",
+            "display_name": "ICE Host Override",
+            "type": "text",
+            "help_text": "(Optional) The IP (or hostname) to be used as the host ICE candidate. If empty, it defaults to resolving via STUN.",
+            "placeholder": "",
+            "default": "",
+            "hosting": "on-prem"
+          },
+          {
+            "key": "ICEServersConfigs",
+            "display_name": "ICE Servers Configurations",
+            "type": "longtext",
+            "help_text": "(Optional) A list of ICE servers (STUN/TURN) configurations to use. This field should contain a valid JSON array.",
+            "placeholder": "[{\n \"urls\":[\"turn:turnserver.example.org:3478\"],\n \"username\": \"webrtc\",\n \"credential\": \"turnpassword\"\n}]",
+            "default": "[{\"urls\":[\"stun:stun.global.calls.mattermost.com:3478\"]}]",
+            "hosting": "on-prem"
+          },
+          {
+            "key": "TURNStaticAuthSecret",
+            "display_name": "TURN Static Auth Secret",
+            "type": "text",
+            "help_text": "(Optional) The secret key used to generate TURN short-lived authentication credentials.",
+            "placeholder": "",
+            "default": "",
+            "hosting": "on-prem"
+          },
+          {
+            "key": "TURNCredentialsExpirationMinutes",
+            "display_name": "TURN Credentials Expiration (minutes)",
+            "type": "number",
+            "help_text": "(Optional) The number of minutes that the generated TURN credentials will be valid for.",
+            "placeholder": "",
+            "default": 1440,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "ServerSideTURN",
+            "display_name": "Server Side TURN",
+            "type": "bool",
+            "help_text": "(Optional) When set to true it will pass and use configured TURN candidates to server initiated connections.",
+            "placeholder": "",
+            "default": false,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "AllowScreenSharing",
+            "display_name": "Allow screen sharing",
+            "type": "bool",
+            "help_text": "When set to true it allows call participants to share their screen.",
+            "placeholder": "",
+            "default": true,
+            "hosting": ""
+          },
+          {
+            "key": "RTCDServiceURL",
+            "display_name": "RTCD service URL",
+            "type": "text",
+            "help_text": "(Optional) The URL to a running RTCD service instance that should host the calls. When set (non empty) all calls will be handled by the external service.",
+            "placeholder": "https://rtcd.example.com",
+            "default": null,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "EnableRecordings",
+            "display_name": "Enable call recordings (Beta)",
+            "type": "bool",
+            "help_text": "(Optional) When set to true it enables the call recordings functionality.",
+            "placeholder": "",
+            "default": false,
+            "hosting": ""
+          },
+          {
+            "key": "JobServiceURL",
+            "display_name": "Job service URL",
+            "type": "text",
+            "help_text": "The URL to a running calls job service instance used for call recordings.",
+            "placeholder": "https://calls-job-service.example.com",
+            "default": null,
+            "hosting": ""
+          },
+          {
+            "key": "MaxRecordingDuration",
+            "display_name": "Maximum call recording duration",
+            "type": "number",
+            "help_text": "The maximum duration (in minutes) for call recordings. Value must be in the range [15, 180].",
+            "placeholder": "",
+            "default": 60,
+            "hosting": ""
+          }
+        ]
+      },
+      "props": {
+        "calls_recorder_version": "v0.2.4",
+        "min_rtcd_version": "v0.9.0"
+      }
+    },
+    "platforms": {
+      "linux-amd64": {
+        "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.14.0-linux-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmQJJXQACgkQ0bVLR6XO/sRKVhAAicvT9IcsBJNnkvoEApW+Ycg0Q2k9AGKo+sq5llScBw5AiZBBDjgr0/hIItrvbfSuJ7wKuafzwu3ENWrwj6aCZGcNHqHzKtr4akQOPgRALnaXHfSmrwR/tqoUyJ2uFS6T0jWS11FKgMmSFUPf9rfMVW7xxvuQ3Nt6hl3Xt4zJC6ZDw6pm4SrDJpbfWmNemwy/PQcFAFzurvdkOVt2dv570+MLzmG/17G3dh4hK5OpdjUS3+MoINmopvqdVXYVamQOxxeYSdfMpSFCMeDX3EOJ7pCxwUf8dZ2bEjRLyBaa0PQl06rrkhm+ZHVuMMSt8PNQ7YVkuYYVHleTDosHsQ7ui01G+m1wkxpfu3Yraspwo+aX2CaaXrwny6dXoXAEZ59kyHyeK4TN1jiwS7K8Kn7DNBJ2pjoyatw+YTDHtygdxNte/ffPzE8ew3xtRmzslCj2g46svrtuFWrUsEPXUtgc3oOcN21A1wqzzA36ehN4ZnvNRnfUmjw/F1Ix8YfWRQ6lfOD+SC62sqJTHdl0kRhP4ogaSNNtBfGtAEL3iVHNT03t9USg6ENa+hZ2x1gHHwP5Z9N0Tt9VX6pL0Mxhx454SHsdhTq2Hc+6W7tBEfzwsh81C1EnEwPo5PXHDtqgqooSaQnpcU9xqEI13kqxWX0+AbVTxWlXWj1QN1AwV2hdE8E="
+      },
+      "darwin-amd64": {},
+      "windows-amd64": {}
+    },
+    "updated_at": "2023-03-09T00:19:12.029167Z"
+  },
+  {
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
+    "icon_data": "",
     "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.13.0.tar.gz",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.13.0",
     "hosting": "",


### PR DESCRIPTION
#### Summary
- NOTE: I had to do this kind of manually, again (see #337)
- cut with `/mb cutplugin --repo mattermost-plugin-calls --tag v0.14.0`
- this commit made with `go run ./cmd/generator/ add mattermost-plugin-calls v0.14.0 --official`

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-50566
