### PR TITLE
Add v0.14.1 of mattermost-plugin-calls to the Marketplace

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -22,8 +22,8 @@
       "min_server_version": "7.5.0",
       "server": {
         "executables": {
-          "linux-amd64": "server/dist/plugin-linux-amd64",
           "darwin-amd64": "server/dist/plugin-darwin-amd64",
+          "linux-amd64": "server/dist/plugin-linux-amd64",
           "windows-amd64": "server/dist/plugin-windows-amd64.exe"
         },
         "executable": ""
@@ -41,7 +41,8 @@
             "type": "custom",
             "help_text": "",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": ""
           }
         ]
       }
@@ -1990,8 +1991,8 @@
       "min_server_version": "5.37.0",
       "server": {
         "executables": {
-          "linux-amd64": "server/dist/plugin-linux-amd64",
           "darwin-amd64": "server/dist/plugin-darwin-amd64",
+          "linux-amd64": "server/dist/plugin-linux-amd64",
           "windows-amd64": "server/dist/plugin-windows-amd64.exe"
         },
         "executable": ""
@@ -2009,7 +2010,8 @@
             "type": "text",
             "help_text": "Trigger Word must be unique, cannot begin with a slash, and cannot contain any spaces.",
             "placeholder": "",
-            "default": "poll"
+            "default": "poll",
+            "hosting": ""
           },
           {
             "key": "ExperimentalUI",
@@ -2017,7 +2019,8 @@
             "type": "bool",
             "help_text": "When true, Matterpoll will render poll posts with a rich UI. The rich UI is not available on the mobile app.",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": ""
           }
         ]
       }
@@ -3668,8 +3671,8 @@
       "min_server_version": "7.2.0",
       "server": {
         "executables": {
-          "linux-amd64": "server/dist/plugin-linux-amd64",
           "darwin-amd64": "server/dist/plugin-darwin-amd64",
+          "linux-amd64": "server/dist/plugin-linux-amd64",
           "windows-amd64": "server/dist/plugin-windows-amd64.exe"
         },
         "executable": ""
@@ -4254,6 +4257,187 @@
   {
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
     "icon_data": "",
+    "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.14.1.tar.gz",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.14.1",
+    "hosting": "",
+    "author_type": "mattermost",
+    "release_stage": "production",
+    "enterprise": false,
+    "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmQTSzQACgkQ0bVLR6XO/sSTeQ//Q3wldR39p7Kz6UxsuQPc6pvHZuG4dBHBNguMce6gIZW0StaREYhdz4ha9iVaQs7GxDxE7wocBbUYAKD758hVKQizAPHs2HnonHL4XjeVDJCwTicGJkrGyWKbNwypTdXkRoRos254kFx9JJeFN5jdA1mS6NIUScQwqpEUkWguLQCG1xGwc2hoNc0mzEdAu71w8HvmT6kkEyE/UrQCu9pqBEc0hVLAwdlA0VooUnwY1A7xJ4cQQMpdXDXnW+MfUf72G04/50gXtihgIFC7hiYblUsttleZ56kJK4pYc8sUf7RUkQweq9B5KH1uJXXro3PT8ixFV66whVY3ky80mRrACYAaPTIDazXbO5zGyI3jHpD/NsuyZ+bkrkLTryFi8WaNJx0Sc3FiLDR7ZwCZ4WMZ3haOPrprbwla4QtLg2E1yzo9CUklzvQbodF77Bsz2DY8SJ2k6UoyAXdkPAXvoRESddHUiWoEiN012mF4J9EG6mP43bO1EC1j5OhcXxBfq7IyuElFnLiD3OOnCgN1y6joEC6u03v90ImIzsrYiCxebxvIOgt0bFa5d/dc7MfmP1ZnlgyKaGxeQMEymnRYd2i37q5qaWWTvpXM7KgP7dD8s3t7eBQZJwtxK/a3K4XAcCQFiKo0H2AdXqnc1YaJ6NeJKmiLhPGacKv46aZdNtlcF6s=",
+    "repo_name": "mattermost-plugin-calls",
+    "manifest": {
+      "id": "com.mattermost.calls",
+      "name": "Calls",
+      "description": "Integrates real-time voice communication in Mattermost",
+      "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
+      "support_url": "https://github.com/mattermost/mattermost-plugin-calls/issues",
+      "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.14.1",
+      "version": "0.14.1",
+      "min_server_version": "7.6.0",
+      "server": {
+        "executables": {
+          "darwin-amd64": "server/dist/plugin-darwin-amd64",
+          "darwin-arm64": "server/dist/plugin-darwin-arm64",
+          "freebsd-amd64": "server/dist/plugin-freebsd-amd64",
+          "linux-amd64": "server/dist/plugin-linux-amd64",
+          "linux-arm64": "server/dist/plugin-linux-arm64",
+          "openbsd-amd64": "server/dist/plugin-openbsd-amd64"
+        },
+        "executable": ""
+      },
+      "webapp": {
+        "bundle_path": "webapp/dist/main.js"
+      },
+      "settings_schema": {
+        "header": "Calls plugin enables voice calls with screensharing in channels. See [documentation](https://docs.mattermost.com/channels/make-calls.html) to learn more.",
+        "footer": "",
+        "settings": [
+          {
+            "key": "DefaultEnabled",
+            "display_name": "Test mode",
+            "type": "custom",
+            "help_text": "When test mode is enabled, only system admins are able to start calls in channels. This allows testing to confirm calls are working as expected.",
+            "placeholder": "",
+            "default": null,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "UDPServerAddress",
+            "display_name": "RTC Server Address",
+            "type": "text",
+            "help_text": "The IP address used by the RTC server to listen on.",
+            "placeholder": "127.0.0.1",
+            "default": "",
+            "hosting": "on-prem"
+          },
+          {
+            "key": "UDPServerPort",
+            "display_name": "RTC Server Port",
+            "type": "number",
+            "help_text": "The UDP port the RTC server will listen on.",
+            "placeholder": "8443",
+            "default": 8443,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "MaxCallParticipants",
+            "display_name": "Max call participants",
+            "type": "number",
+            "help_text": "The maximum number of participants that can join a call. If left empty, or set to 0, it means unlimited.",
+            "placeholder": "",
+            "default": 0,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "ICEHostOverride",
+            "display_name": "ICE Host Override",
+            "type": "text",
+            "help_text": "(Optional) The IP (or hostname) to be used as the host ICE candidate. If empty, it defaults to resolving via STUN.",
+            "placeholder": "",
+            "default": "",
+            "hosting": "on-prem"
+          },
+          {
+            "key": "ICEServersConfigs",
+            "display_name": "ICE Servers Configurations",
+            "type": "longtext",
+            "help_text": "(Optional) A list of ICE servers (STUN/TURN) configurations to use. This field should contain a valid JSON array.",
+            "placeholder": "[{\n \"urls\":[\"turn:turnserver.example.org:3478\"],\n \"username\": \"webrtc\",\n \"credential\": \"turnpassword\"\n}]",
+            "default": "[{\"urls\":[\"stun:stun.global.calls.mattermost.com:3478\"]}]",
+            "hosting": "on-prem"
+          },
+          {
+            "key": "TURNStaticAuthSecret",
+            "display_name": "TURN Static Auth Secret",
+            "type": "text",
+            "help_text": "(Optional) The secret key used to generate TURN short-lived authentication credentials.",
+            "placeholder": "",
+            "default": "",
+            "hosting": "on-prem"
+          },
+          {
+            "key": "TURNCredentialsExpirationMinutes",
+            "display_name": "TURN Credentials Expiration (minutes)",
+            "type": "number",
+            "help_text": "(Optional) The number of minutes that the generated TURN credentials will be valid for.",
+            "placeholder": "",
+            "default": 1440,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "ServerSideTURN",
+            "display_name": "Server Side TURN",
+            "type": "bool",
+            "help_text": "(Optional) When set to true it will pass and use configured TURN candidates to server initiated connections.",
+            "placeholder": "",
+            "default": false,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "AllowScreenSharing",
+            "display_name": "Allow screen sharing",
+            "type": "bool",
+            "help_text": "When set to true it allows call participants to share their screen.",
+            "placeholder": "",
+            "default": true,
+            "hosting": ""
+          },
+          {
+            "key": "RTCDServiceURL",
+            "display_name": "RTCD service URL",
+            "type": "text",
+            "help_text": "(Optional) The URL to a running RTCD service instance that should host the calls. When set (non empty) all calls will be handled by the external service.",
+            "placeholder": "https://rtcd.example.com",
+            "default": null,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "EnableRecordings",
+            "display_name": "Enable call recordings (Beta)",
+            "type": "bool",
+            "help_text": "(Optional) When set to true it enables the call recordings functionality.",
+            "placeholder": "",
+            "default": false,
+            "hosting": ""
+          },
+          {
+            "key": "JobServiceURL",
+            "display_name": "Job service URL",
+            "type": "text",
+            "help_text": "The URL to a running calls job service instance used for call recordings.",
+            "placeholder": "https://calls-job-service.example.com",
+            "default": null,
+            "hosting": ""
+          },
+          {
+            "key": "MaxRecordingDuration",
+            "display_name": "Maximum call recording duration",
+            "type": "number",
+            "help_text": "The maximum duration (in minutes) for call recordings. Value must be in the range [15, 180].",
+            "placeholder": "",
+            "default": 60,
+            "hosting": ""
+          }
+        ]
+      },
+      "props": {
+        "calls_recorder_version": "v0.2.5",
+        "min_rtcd_version": "v0.9.0"
+      }
+    },
+    "platforms": {
+      "linux-amd64": {
+        "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.14.1-linux-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmQTSzEACgkQ0bVLR6XO/sQy+RAAl8J5c+h2R4GGLL7XwtjGDz/zL2g5BAPtcbffhtXZwOwDMknc1wdg+jBCacG582fGvG9fy39bUjyDZAsA/U6lK879MSH0UT/HaBa2BLn87cX3RKrH3UuZ/iyIEyC5k33sUnFsXzGRgMM6URK8gI0zFAEujqUal8RFrB2wSJAUXILg2jRDtu+JabB0zFCAMsHoPaUOevZFIRAomVU4v7U7f7UPeICU7NkRjMvKSZxqVT0pVMCusMjBjrGvATnJ+wzMIqzzFhbS+i5MIyxt8eZntcEsvH78umcJyXZ/YPJ4xyP/CtgbwXflsmtjBKCYJvVdtggVfvPCyOoXCKODDYfqyBVxt0duVfDPyOhSkxNc2N1bJdze0MfQJH9Ju3iGt41nYN6ErR6Q0B3BHsZCnXb9cxEGU5dimeoOtfdmIWd4zYrC/ngBZsvVqS3MOe5IXyvQqkA5Kv8XkGQw0bM/E/ExY2YS78E/XWn7rgEjCG6aseod71lAsRkZzya8gde8i41bRhikvvKwUDIe8vG6NadXM+wLFF3B1tnN0ratGPnep9ly90mEoxWM66OlVjKwjG4LF9AyQzK7mEw2c7dE5MFTFSjI73U15vldeFMLh7CHJlnnLRzL1nc/psXSdeEIZqF6w66sbXaOOI8/vs8KoF9Ocfopu5ZJR78In4kz/uIjlNs="
+      },
+      "darwin-amd64": {},
+      "windows-amd64": {}
+    },
+    "updated_at": "2023-03-16T17:22:08.713997Z"
+  },
+  {
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
+    "icon_data": "",
     "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.14.0.tar.gz",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.14.0",
     "hosting": "",
@@ -4454,8 +4638,8 @@
       "min_server_version": "7.6.0",
       "server": {
         "executables": {
-          "linux-amd64": "server/dist/plugin-linux-amd64",
-          "darwin-amd64": "server/dist/plugin-darwin-amd64"
+          "darwin-amd64": "server/dist/plugin-darwin-amd64",
+          "linux-amd64": "server/dist/plugin-linux-amd64"
         },
         "executable": ""
       },
@@ -4472,7 +4656,8 @@
             "type": "custom",
             "help_text": "When test mode is enabled, only system admins are able to start calls in channels. This allows testing to confirm calls are working as expected.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": ""
           },
           {
             "key": "UDPServerAddress",
@@ -4480,7 +4665,8 @@
             "type": "text",
             "help_text": "The IP address used by the RTC server to listen on.",
             "placeholder": "127.0.0.1",
-            "default": ""
+            "default": "",
+            "hosting": ""
           },
           {
             "key": "UDPServerPort",
@@ -4488,7 +4674,8 @@
             "type": "number",
             "help_text": "The UDP port the RTC server will listen on.",
             "placeholder": "8443",
-            "default": 8443
+            "default": 8443,
+            "hosting": ""
           },
           {
             "key": "MaxCallParticipants",
@@ -4496,7 +4683,8 @@
             "type": "number",
             "help_text": "The maximum number of participants that can join a call. If left empty, or set to 0, it means unlimited.",
             "placeholder": "",
-            "default": 0
+            "default": 0,
+            "hosting": ""
           },
           {
             "key": "ICEHostOverride",
@@ -4504,7 +4692,8 @@
             "type": "text",
             "help_text": "(Optional) The IP (or hostname) to be used as the host ICE candidate. If empty, it defaults to resolving via STUN.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": ""
           },
           {
             "key": "ICEServersConfigs",
@@ -4512,7 +4701,8 @@
             "type": "longtext",
             "help_text": "(Optional) A list of ICE servers (STUN/TURN) configurations to use. This field should contain a valid JSON array.",
             "placeholder": "[{\n \"urls\":[\"turn:turnserver.example.org:3478\"],\n \"username\": \"webrtc\",\n \"credential\": \"turnpassword\"\n}]",
-            "default": "[{\"urls\":[\"stun:stun.global.calls.mattermost.com:3478\"]}]"
+            "default": "[{\"urls\":[\"stun:stun.global.calls.mattermost.com:3478\"]}]",
+            "hosting": ""
           },
           {
             "key": "TURNStaticAuthSecret",
@@ -4520,7 +4710,8 @@
             "type": "text",
             "help_text": "(Optional) The secret key used to generate TURN short-lived authentication credentials.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": ""
           },
           {
             "key": "TURNCredentialsExpirationMinutes",
@@ -4528,7 +4719,8 @@
             "type": "number",
             "help_text": "(Optional) The number of minutes that the generated TURN credentials will be valid for.",
             "placeholder": "",
-            "default": 1440
+            "default": 1440,
+            "hosting": ""
           },
           {
             "key": "ServerSideTURN",
@@ -4536,7 +4728,8 @@
             "type": "bool",
             "help_text": "(Optional) When set to true it will pass and use configured TURN candidates to server initiated connections.",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": ""
           },
           {
             "key": "AllowScreenSharing",
@@ -4544,7 +4737,8 @@
             "type": "bool",
             "help_text": "When set to true it allows call participants to share their screen.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": ""
           },
           {
             "key": "RTCDServiceURL",
@@ -4552,7 +4746,8 @@
             "type": "text",
             "help_text": "(Optional) The URL to a running RTCD service instance that should host the calls. When set (non empty) all calls will be handled by the external service.",
             "placeholder": "https://rtcd.example.com",
-            "default": null
+            "default": null,
+            "hosting": ""
           },
           {
             "key": "EnableRecordings",
@@ -4560,7 +4755,8 @@
             "type": "bool",
             "help_text": "(Optional) When set to true it enables the call recordings functionality.",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": ""
           },
           {
             "key": "JobServiceURL",
@@ -4568,7 +4764,8 @@
             "type": "text",
             "help_text": "The URL to a running calls job service instance used for call recordings.",
             "placeholder": "https://calls-job-service.example.com",
-            "default": null
+            "default": null,
+            "hosting": ""
           },
           {
             "key": "MaxRecordingDuration",
@@ -4576,7 +4773,8 @@
             "type": "number",
             "help_text": "The maximum duration (in minutes) for call recordings. Value must be in the range [15, 180].",
             "placeholder": "",
-            "default": 60
+            "default": 60,
+            "hosting": ""
           }
         ]
       },
@@ -4617,8 +4815,8 @@
       "min_server_version": "7.6.0",
       "server": {
         "executables": {
-            "linux-amd64": "server/dist/plugin-linux-amd64",
-            "darwin-amd64": "server/dist/plugin-darwin-amd64"
+          "darwin-amd64": "server/dist/plugin-darwin-amd64",
+          "linux-amd64": "server/dist/plugin-linux-amd64"
         },
         "executable": ""
       },
@@ -4784,8 +4982,8 @@
       "min_server_version": "7.7.0",
       "server": {
         "executables": {
-            "linux-amd64": "server/dist/plugin-linux-amd64",
-            "darwin-amd64": "server/dist/plugin-darwin-amd64"
+          "darwin-amd64": "server/dist/plugin-darwin-amd64",
+          "linux-amd64": "server/dist/plugin-linux-amd64"
         },
         "executable": ""
       },
@@ -11477,8 +11675,8 @@
       "min_server_version": "6.5.0",
       "server": {
         "executables": {
-          "linux-amd64": "server/dist/plugin-linux-amd64",
           "darwin-amd64": "server/dist/plugin-darwin-amd64",
+          "linux-amd64": "server/dist/plugin-linux-amd64",
           "windows-amd64": "server/dist/plugin-windows-amd64.exe"
         },
         "executable": ""
@@ -11496,7 +11694,8 @@
             "type": "bool",
             "help_text": "When **false**, users cannot attach and create Jira issues in Mattermost. Does not affect Jira webhook notifications. Select **false** then disable and re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When **true**, install this plugin to your Jira instance with `/jira install` to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": ""
           },
           {
             "key": "secret",
@@ -11505,7 +11704,8 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Jira integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": ""
           },
           {
             "key": "RolesAllowedToEditJiraSubscriptions",
@@ -11531,7 +11731,8 @@
                 "display_name": "System Admins",
                 "value": "system_admin"
               }
-            ]
+            ],
+            "hosting": ""
           },
           {
             "key": "GroupsAllowedToEditJiraSubscriptions",
@@ -11539,7 +11740,8 @@
             "type": "text",
             "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription. Jira groups restrictions are only applicable for a legacy instance installed on Jira 2.4 or earlier.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": ""
           },
           {
             "key": "JiraAdminAdditionalHelpText",
@@ -11547,7 +11749,8 @@
             "type": "text",
             "help_text": "Additional Help Text to be shown to the user along with the output of `/jira help` command.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": ""
           },
           {
             "key": "HideDecriptionComment",
@@ -11555,7 +11758,8 @@
             "type": "bool",
             "help_text": "Hide detailed issue descriptions and comments from Subscription and Webhook messages",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": ""
           },
           {
             "key": "EnableAutocomplete",
@@ -11563,7 +11767,8 @@
             "type": "bool",
             "help_text": "Autocomplete guides users through the available `/jira` slash commands.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": ""
           },
           {
             "key": "DisplaySubscriptionNameInNotifications",
@@ -11571,7 +11776,8 @@
             "type": "bool",
             "help_text": "Display subscription name in post when a subscription posts to a channel",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": ""
           }
         ]
       }
@@ -11615,8 +11821,8 @@
       "min_server_version": "6.5.0",
       "server": {
         "executables": {
-          "linux-amd64": "server/dist/plugin-linux-amd64",
           "darwin-amd64": "server/dist/plugin-darwin-amd64",
+          "linux-amd64": "server/dist/plugin-linux-amd64",
           "windows-amd64": "server/dist/plugin-windows-amd64.exe"
         },
         "executable": ""
@@ -11634,7 +11840,8 @@
             "type": "bool",
             "help_text": "When **false**, users cannot attach and create Jira issues in Mattermost. Does not affect Jira webhook notifications. Select **false** then disable and re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When **true**, install this plugin to your Jira instance with `/jira install` to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": ""
           },
           {
             "key": "secret",
@@ -11643,7 +11850,8 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Jira integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": ""
           },
           {
             "key": "RolesAllowedToEditJiraSubscriptions",
@@ -11669,7 +11877,8 @@
                 "display_name": "System Admins",
                 "value": "system_admin"
               }
-            ]
+            ],
+            "hosting": ""
           },
           {
             "key": "GroupsAllowedToEditJiraSubscriptions",
@@ -11677,7 +11886,8 @@
             "type": "text",
             "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription. Jira groups restrictions are only applicable for a legacy instance installed on Jira 2.4 or earlier.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": ""
           },
           {
             "key": "JiraAdminAdditionalHelpText",
@@ -11685,7 +11895,8 @@
             "type": "text",
             "help_text": "Additional Help Text to be shown to the user along with the output of `/jira help` command.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": ""
           },
           {
             "key": "HideDecriptionComment",
@@ -11693,7 +11904,8 @@
             "type": "bool",
             "help_text": "Hide detailed issue descriptions and comments from Subscription and Webhook messages",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": ""
           },
           {
             "key": "EnableAutocomplete",
@@ -11701,7 +11913,8 @@
             "type": "bool",
             "help_text": "Autocomplete guides users through the available `/jira` slash commands.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": ""
           },
           {
             "key": "DisplaySubscriptionNameInNotifications",
@@ -11709,7 +11922,8 @@
             "type": "bool",
             "help_text": "Display subscription name in post when a subscription posts to a channel",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": ""
           }
         ]
       }


### PR DESCRIPTION
#### Summary
- dot release to fix a bad bug in the recorder
- cut with `/mb cutplugin --tag v0.14.1 --repo mattermost-plugin-calls --commitSHA 740ed9fcbde317205b618ab37223f1d13d39557f`
- this commit made with `go run ./cmd/generator/ add mattermost-plugin-calls v0.14.1 --official`
- There are some other lines that the generator fixed, that's because of the recent master->production merge. Let's commit those here so other plugins don't have to.

#### Ticket Link
- none
