### PR TITLE
Fix linting rule: Use underscore to convey unused variable

### DIFF
--- a/internal/api/health_check.go
+++ b/internal/api/health_check.go
@@ -32,7 +32,7 @@ func initHealthCheck(apiRouter *mux.Router, context *Context) {
 
 // handleHealthCheck responds to GET /api/v1/health,
 // returning information about the service and what commit was used to run it.
-func handleHealthCheck(c *Context, w http.ResponseWriter, r *http.Request) {
+func handleHealthCheck(c *Context, w http.ResponseWriter, _ *http.Request) {
 	buildInfo := make(map[string]string)
 	buildInfo["buildHash"] = buildHash
 	buildInfo["buildHashShort"] = buildHashShort

--- a/internal/api/label.go
+++ b/internal/api/label.go
@@ -19,7 +19,7 @@ func initLabels(apiRouter *mux.Router, context *Context) {
 }
 
 // handleGetPlugins responds to GET /api/v1/labels, returning a list of all defined labels.
-func handleGetLabels(c *Context, w http.ResponseWriter, r *http.Request) {
+func handleGetLabels(c *Context, w http.ResponseWriter, _ *http.Request) {
 	response := model.AllLabels
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
#### Summary

The CI checks on https://github.com/mattermost/mattermost-marketplace/pull/356 are currently failing due to a linting error regarding unused function parameter `r *http.Request`. This PR fixes the issue by using underscores to convey that this is not used.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

