### PR TITLE
MM-52936 - Add v0.16.1 of mattermost-plugin-calls to the Marketplace

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -4408,6 +4408,219 @@
   {
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
     "icon_data": "",
+    "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.16.1.tar.gz",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.16.1",
+    "hosting": "",
+    "author_type": "mattermost",
+    "release_stage": "production",
+    "enterprise": false,
+    "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmRvY1oACgkQ0bVLR6XO/sT0VQ//Vd7UL2M+gycSYOZclWQhEgi8/c7T9YUM0uUsGQTwiZ8iTus7dJ3gvZsKs5zrAd6TFByz3NMOybuo5x8QLM2XaoqnIIVFL0b9oOtVPJGp2EODr4iorf6AqBYDHdyl0pJfNs7yimRymM4JCAKStcsakKMird5l3Sh1RWmBnA6xkjTlXBg0yu3UUMiDk0OWK7KNC8tRDJyLCbxfbu7yb9fiNKU3iAd12qY43gOxmVaI1OoyaYX7mVp7VtuWMSNcHu92AkfZI7FvKjkew/DhBTkKIbnmV7IQ23iwBDThKB/vBI974NYzNJWLLUTg7IuzstvmABISCfJrs2db7+DYJ1xniv9Od7o4S581HmGGSI83IFJHttfC56rC7WEWzZ7QVL/4TnmcQziBrsArbbLnunRmoP0ogW1pT22P+NrG21+GJKv+cOgq7H8MjMxhquwzuxt7najlzqc06QU4rJ/Q5sJ+HoHJAkYqQnCrwycEHNsLNPqE3rVdr48XRCF4X4PZDHQkYoDdaWosLQi2tafptXMBvx65UuSZlAbfO4vu+eYm+NniwkdztWR69P4AiRDmnZk0/vNsZ4EuPahIzeE5TLu0bAAkjReVAllSBZud8T/jm92Eo41tfc+lEgoFGN5qeBHDCYGakUQ77DClWdrC1E7ZvrgL+rFFPeAqYii1ViJ5rIg=",
+    "repo_name": "mattermost-plugin-calls",
+    "manifest": {
+      "id": "com.mattermost.calls",
+      "name": "Calls",
+      "description": "Integrates real-time voice communication in Mattermost",
+      "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
+      "support_url": "https://github.com/mattermost/mattermost-plugin-calls/issues",
+      "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.16.1",
+      "version": "0.16.1",
+      "min_server_version": "7.6.0",
+      "server": {
+        "executables": {
+          "darwin-amd64": "server/dist/plugin-darwin-amd64",
+          "darwin-arm64": "server/dist/plugin-darwin-arm64",
+          "freebsd-amd64": "server/dist/plugin-freebsd-amd64",
+          "linux-amd64": "server/dist/plugin-linux-amd64",
+          "linux-arm64": "server/dist/plugin-linux-arm64",
+          "openbsd-amd64": "server/dist/plugin-openbsd-amd64"
+        },
+        "executable": ""
+      },
+      "webapp": {
+        "bundle_path": "webapp/dist/main.js"
+      },
+      "settings_schema": {
+        "header": "Calls plugin enables voice calls with screensharing in channels. See [documentation](https://docs.mattermost.com/channels/make-calls.html) to learn more.",
+        "footer": "",
+        "settings": [
+          {
+            "key": "DefaultEnabled",
+            "display_name": "Test mode",
+            "type": "custom",
+            "help_text": "When test mode is enabled, only system admins are able to start calls in channels. This allows testing to confirm calls are working as expected.",
+            "placeholder": "",
+            "default": null,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "UDPServerAddress",
+            "display_name": "RTC Server Address",
+            "type": "text",
+            "help_text": "The IP address used by the RTC server to listen on.",
+            "placeholder": "127.0.0.1",
+            "default": "",
+            "hosting": "on-prem"
+          },
+          {
+            "key": "UDPServerPort",
+            "display_name": "RTC Server Port",
+            "type": "number",
+            "help_text": "The UDP port the RTC server will listen on.",
+            "placeholder": "8443",
+            "default": 8443,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "MaxCallParticipants",
+            "display_name": "Max call participants",
+            "type": "number",
+            "help_text": "The maximum number of participants that can join a call. If left empty, or set to 0, it means unlimited.",
+            "placeholder": "",
+            "default": 0,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "ICEHostOverride",
+            "display_name": "ICE Host Override",
+            "type": "text",
+            "help_text": "(Optional) The IP (or hostname) to be used as the host ICE candidate. If empty, it defaults to resolving via STUN.",
+            "placeholder": "",
+            "default": "",
+            "hosting": "on-prem"
+          },
+          {
+            "key": "ICEServersConfigs",
+            "display_name": "ICE Servers Configurations",
+            "type": "longtext",
+            "help_text": "(Optional) A list of ICE servers (STUN/TURN) configurations to use. This field should contain a valid JSON array.",
+            "placeholder": "[{\n \"urls\":[\"turn:turnserver.example.org:3478\"],\n \"username\": \"webrtc\",\n \"credential\": \"turnpassword\"\n}]",
+            "default": "[{\"urls\":[\"stun:stun.global.calls.mattermost.com:3478\"]}]",
+            "hosting": "on-prem"
+          },
+          {
+            "key": "TURNStaticAuthSecret",
+            "display_name": "TURN Static Auth Secret",
+            "type": "text",
+            "help_text": "(Optional) The secret key used to generate TURN short-lived authentication credentials.",
+            "placeholder": "",
+            "default": "",
+            "hosting": "on-prem"
+          },
+          {
+            "key": "TURNCredentialsExpirationMinutes",
+            "display_name": "TURN Credentials Expiration (minutes)",
+            "type": "number",
+            "help_text": "(Optional) The number of minutes that the generated TURN credentials will be valid for.",
+            "placeholder": "",
+            "default": 1440,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "ServerSideTURN",
+            "display_name": "Server Side TURN",
+            "type": "bool",
+            "help_text": "(Optional) When set to true it will pass and use configured TURN candidates to server initiated connections.",
+            "placeholder": "",
+            "default": false,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "AllowScreenSharing",
+            "display_name": "Allow screen sharing",
+            "type": "bool",
+            "help_text": "When set to true it allows call participants to share their screen.",
+            "placeholder": "",
+            "default": true,
+            "hosting": ""
+          },
+          {
+            "key": "EnableSimulcast",
+            "display_name": "Enable simulcast for screen sharing (Experimental)",
+            "type": "bool",
+            "help_text": "When set to true it enables simulcast for screen sharing. This can help to improve screen sharing quality.",
+            "placeholder": "",
+            "default": false,
+            "hosting": ""
+          },
+          {
+            "key": "RTCDServiceURL",
+            "display_name": "RTCD service URL",
+            "type": "text",
+            "help_text": "(Optional) The URL to a running RTCD service instance that should host the calls. When set (non empty) all calls will be handled by the external service.",
+            "placeholder": "https://rtcd.example.com",
+            "default": null,
+            "hosting": "on-prem"
+          },
+          {
+            "key": "EnableRecordings",
+            "display_name": "Enable call recordings (Beta)",
+            "type": "bool",
+            "help_text": "(Optional) When set to true it enables the call recordings functionality.",
+            "placeholder": "",
+            "default": false,
+            "hosting": ""
+          },
+          {
+            "key": "JobServiceURL",
+            "display_name": "Job service URL",
+            "type": "text",
+            "help_text": "The URL to a running calls job service instance used for call recordings.",
+            "placeholder": "https://calls-job-service.example.com",
+            "default": null,
+            "hosting": ""
+          },
+          {
+            "key": "MaxRecordingDuration",
+            "display_name": "Maximum call recording duration",
+            "type": "number",
+            "help_text": "The maximum duration (in minutes) for call recordings. Value must be in the range [15, 180].",
+            "placeholder": "",
+            "default": 60,
+            "hosting": ""
+          },
+          {
+            "key": "RecordingQuality",
+            "display_name": "Call recording quality",
+            "type": "dropdown",
+            "help_text": "The audio and video quality of call recordings.\n Note: this setting can affect the overall performance of the job service and the number of concurrent recording jobs that can be run.",
+            "placeholder": "",
+            "default": "medium",
+            "options": [
+              {
+                "display_name": "Low",
+                "value": "low"
+              },
+              {
+                "display_name": "Medium",
+                "value": "medium"
+              },
+              {
+                "display_name": "High",
+                "value": "high"
+              }
+            ],
+            "hosting": "on-prem"
+          }
+        ]
+      },
+      "props": {
+        "calls_recorder_version": "v0.3.2",
+        "min_rtcd_version": "v0.10.1"
+      }
+    },
+    "platforms": {
+      "linux-amd64": {
+        "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.16.1-linux-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmRvY1cACgkQ0bVLR6XO/sQCOg//cDv2GRtIpfc34vcLXgjLVb0dnEf5H11okv9hzrmih4NMxQnYTlxSLmri152UncpN/vf0L4Oy1cAVLZGV8cTvZxxP5bVHk2r5AAAFhKkjvc3x6NV4uTePdFBMFiFrw90Ft9ACzcQXwRsvmabvyOtAP9YuCD6QicSENN63LU7DfU96ojfvB8yOSIq5XHEhJYIDQKulu1U6LaOKvFpyx4m+oVvycydws1J4XHxvu9VjA3kxr4e5p2KqFM7adWdThlPURBQvQxZYajWdveSlbOja85SlWxMKVR2/4cNWpRgv+crCxNaO3YIIS79O9NRyeje0ixFE13g9vRvhTpd7WKxdtMJeopfgEkgp6h3cyOQHEqdrSJ38TxP5RbhSv+tSkgnb0N4Nzsoxcj7PTougvwpDeysQpcAXQ4ULxN/Ytf3NoTQ/Cr4kK7THfQYFr3sY2g3oz0bHIK0mqTLh23zP6gxvRep72kCkgOzhQ8EAil0cYb1sQ5TLPOxQCldtI+nzLSQvjH7hT9AzxDFO3zXPsYeoIGSet4jrgjj/snPi9HwcZZwoGe3uF2If05P1J3qBdxi/zW/9PU1VzBmvuT6e931tp/lViQCE+vd6b7CiE9TBYD+wY7ftesqIVShqF3NiFj57Tt+eMpINzIBN32ycbyc9DckaPI/uxMKW84xqpU3ysdE="
+      },
+      "darwin-amd64": {},
+      "windows-amd64": {}
+    },
+    "updated_at": "2023-05-25T15:22:45.302977Z"
+  },
+  {
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-calls/",
+    "icon_data": "",
     "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-calls-v0.16.0.tar.gz",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.16.0",
     "hosting": "",


### PR DESCRIPTION
#### Summary
- cut with `/mb cutplugin --repo mattermost-plugin-calls --tag v0.16.1`
- this commit made with `go run ./cmd/generator/ add mattermost-plugin-calls v0.16.1 --official`

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-52936


