### PR TITLE
Removes antivirus-v1.0.0 and welcomebot-v1.3.0 from Cloud listings

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -10887,7 +10887,7 @@
     "icon_data": "",
     "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-welcomebot-v1.3.0.tar.gz",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-welcomebot/releases/tag/v1.3.0",
-    "hosting": "",
+    "hosting": "on-prem",
     "author_type": "mattermost",
     "release_stage": "production",
     "enterprise": false,

--- a/plugins.json
+++ b/plugins.json
@@ -68,7 +68,7 @@
     "icon_data": "",
     "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-antivirus-v1.0.0.tar.gz",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-antivirus/releases/tag/v1.0.0",
-    "hosting": "",
+    "hosting": "on-prem",
     "author_type": "mattermost",
     "release_stage": "production",
     "enterprise": false,


### PR DESCRIPTION
#### Summary
Removes `mattermost-plugin-antivirus` and `mattermost-plugin-welcomebot` from Cloud listings. E.g. https://api.integrations.mattermost.com/api/v1/plugins?server_version=8.1.0&page=0&per_page=500&cloud=true&enterprise_plugins=true
