### PR TITLE
Check for master branch existence before creating it, in build workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: build/ensure-master-exists
-      run: git rev-parse --verify master || git branch master origin/master
+      run: git rev-parse --verify master >/dev/null 2>&1 || git branch master origin/master
     - name: build/check-style
       run: make check-style
     - name: build/test

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: build/ensure-master-exists
-      run: git branch master origin/master
+      run: git rev-parse --verify master || git branch master origin/master
     - name: build/check-style
       run: make check-style
     - name: build/test


### PR DESCRIPTION
#### Summary

Quickfix for https://github.com/mattermost/mattermost-marketplace/pull/393 : for the `build` workflow to run on non-master branch, we needed to create a local version of in in the checked-out repo, in order for the build scripts to work.

However, for workflows on `master` branch, the same command fails since the [master branch already exists](https://github.com/mattermost/mattermost-marketplace/actions/runs/6890904338/job/18744869517#step:4:5).

As a solution, we check if master branch exists, before attempting to create it.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-6549