### PR TITLE
CLD-6708 Increase serverless verbosity, persist lambda artifact

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -63,13 +63,13 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.MM_MARKETPLACE_AWS_ACCESS_KEY_ID_STAGING }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.MM_MARKETPLACE_AWS_SECRET_ACCESS_KEY_STAGING }}
-      run: serverless --verbose deploy function -f server --stage staging
+      run: serverless deploy function -f server --stage staging --verbose
     - name: deploy/production-branch
       if: ${{ github.ref_name == 'production' }}
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.MM_MARKETPLACE_AWS_ACCESS_KEY_ID_PRODUCTION }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.MM_MARKETPLACE_AWS_SECRET_ACCESS_KEY_PRODUCTION }}
-      run: serverless --verbose deploy function -f server --stage production
+      run: serverless deploy function -f server --stage production --verbose
     - name: deploy/persist-lambda-artifact
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -63,10 +63,16 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.MM_MARKETPLACE_AWS_ACCESS_KEY_ID_STAGING }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.MM_MARKETPLACE_AWS_SECRET_ACCESS_KEY_STAGING }}
-      run: serverless deploy function -f server --stage staging
+      run: serverless --verbose deploy function -f server --stage staging
     - name: deploy/production-branch
       if: ${{ github.ref_name == 'production' }}
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.MM_MARKETPLACE_AWS_ACCESS_KEY_ID_PRODUCTION }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.MM_MARKETPLACE_AWS_SECRET_ACCESS_KEY_PRODUCTION }}
-      run: serverless deploy function -f server --stage production
+      run: serverless --verbose deploy function -f server --stage production
+    - name: deploy/persist-lambda-artifact
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      with:
+        name: marketplace-lambda-artifact
+        path: .serverless/mattermost-marketplace.zip
+        retention-days: 7


### PR DESCRIPTION
#### Summary

Increase verbosity of the `serverless` function, and store the deployment artifact, for better debuggability.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-6708