### PR TITLE
Production: Fix GH action workflow for notifying incoming webhooks on community/hub servers

### DIFF
--- a/.github/workflows/notify-mm-blog.yml
+++ b/.github/workflows/notify-mm-blog.yml
@@ -17,12 +17,11 @@ jobs:
         shell: bash
         run: |
           .github/workflows/notify-mm-blog.sh
-      - name: Notify channel 1
+      - name: Notify "Community Configuration" channel on community
         uses: mattermost/action-mattermost-notify@master
         env:
-          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL_1 }}
-      - name: Notify channel 2
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MM_COMMUNITY_COMMUNITY_CONFIGURATION_INCOMING_WEBHOOK }}
+      - name: Notify "Announcements" channel on hub
         uses: mattermost/action-mattermost-notify@master
         env:
-          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL_2 }}
-
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MM_HUB_ANNOUNCEMENTS_INCOMING_WEBHOOK }}


### PR DESCRIPTION
#### Summary

This PR uses newly set environment variables with incoming webhooks to send release updates to the community/hub servers.

This PR is for the production branch. Here's the one for the master branch https://github.com/mattermost/mattermost-marketplace/pull/440

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/CLD-7673

https://hub.mattermost.com/private-core/pl/cdque38knirqpet1soc8x1398e
