### PR TITLE
Update enterprise label

### DIFF
--- a/internal/model/label.go
+++ b/internal/model/label.go
@@ -41,6 +41,6 @@ var ExperimentalLabel = Label{
 
 var EnterpriseLabel = Label{
 	Name:        "Enterprise",
-	Description: "This plugin requires an Mattermost Enterprise license.",
+	Description: "This plugin requires a Mattermost Enterprise license.",
 	URL:         "https://mattermost.com/pricing/",
 }

--- a/internal/model/label.go
+++ b/internal/model/label.go
@@ -40,7 +40,7 @@ var ExperimentalLabel = Label{
 }
 
 var EnterpriseLabel = Label{
-	Name:        "Professional/Enterprise",
-	Description: "This plugin requires a Professional or Enterprise subscription.",
+	Name:        "Enterprise",
+	Description: "This plugin requires an Mattermost Enterprise license.",
 	URL:         "https://mattermost.com/pricing/",
 }


### PR DESCRIPTION
The MS Teams plugin is the only plugin in the marketplace to use this SKU label, so for accuracy this PR updates the help text and label to "Enterprise" 