### PR TITLE
Update CI to work with new lambda artifact

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -11,7 +11,7 @@ jobs:
         shell: bash
     steps:
     - name: build/checkout-repo
-      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         fetch-depth: 0
     - name: build/ensure-master-exists
@@ -22,6 +22,8 @@ jobs:
       run: make test
     - name: build/build
       run: make build
+    - name: build/package-artifact
+      run: make package-artifact
     - name: build/check-uncommitted-changes
       run: |
         # Assert that 'git status --porcelain' does not produce output
@@ -31,10 +33,10 @@ jobs:
           exit 1
         }
     - name: build/persist-build
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         name: marketplace-build
-        path: dist/
+        path: dist/mattermost-marketplace.zip
         retention-days: 2
 
   deploy:
@@ -50,14 +52,14 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
     steps:
     - name: build/checkout-repo
-      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: deploy/install-dependencies
       run: npm i -g "serverless@<4.0.0"
     - name: deploy/download-build
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
       with:
         name: marketplace-build
-        path: dist/
+        path: dist/mattermost-marketplace.zip
     # Required because of https://github.com/actions/upload-artifact/issues/38
     - name: deploy/set-artifact-permissions
       run: chmod +x dist/*


### PR DESCRIPTION
#### Summary

The deploy step is currently [failing](https://github.com/mattermost/mattermost-marketplace/actions/runs/10904226898/job/30260222151) after https://github.com/mattermost/mattermost-marketplace/pull/457 went in because the expected file is not found. 

I don't really have a good way to test this, so I tried my best, but please let me know if you have any thoughts.