### PR TITLE
Upgrade channel export plugin to v1.2.1

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -33,7 +33,9 @@
             "type": "text",
             "help_text": "The hostname and port to connect to clamd",
             "placeholder": "localhost:3310",
-            "default": "localhost:3310"
+            "default": "localhost:3310",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ScanTimeoutSeconds",
@@ -41,9 +43,12 @@
             "type": "number",
             "help_text": "How long the virus scan can take before giving up.",
             "placeholder": "10",
-            "default": 10
+            "default": 10,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -96,7 +101,9 @@
             "type": "text",
             "help_text": "The hostname and port to connect to clamd",
             "placeholder": "localhost:3310",
-            "default": "localhost:3310"
+            "default": "localhost:3310",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ScanTimeoutSeconds",
@@ -104,9 +111,12 @@
             "type": "number",
             "help_text": "How long the virus scan can take before giving up.",
             "placeholder": "10",
-            "default": 10
+            "default": 10,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -155,7 +165,9 @@
             "type": "bool",
             "help_text": "When user joins to a team, recommend bot is going to recommend interesting channels in that team.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "RecommendOnJoinChannel",
@@ -163,7 +175,9 @@
             "type": "bool",
             "help_text": "When user joins to a channel, recommend bot is going to recommend other channels in the team based on the people in that channel.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ActivityThreshold",
@@ -171,7 +185,9 @@
             "type": "number",
             "help_text": "When the bot recommends you the most active channels, what is the time (in minutes) that is used to count activity. By default is a week. In instances with a lot of activity we recommend to adjust this to smaller value.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GracePeriod",
@@ -179,9 +195,12 @@
             "type": "number",
             "help_text": "Give a period of time since the user was created before start sending automatic messages on join.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -233,7 +252,9 @@
             "type": "text",
             "help_text": "The base URL for using the plugin with a GitLab installation. Examples: https://gitlab.com or https://gitlab.example.com",
             "placeholder": "https://gitlab.com",
-            "default": "https://gitlab.com"
+            "default": "https://gitlab.com",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabOAuthClientID",
@@ -241,7 +262,9 @@
             "type": "text",
             "help_text": "The client ID for the OAuth app registered with GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabOAuthClientSecret",
@@ -249,7 +272,9 @@
             "type": "text",
             "help_text": "The client secret for the OAuth app registered with GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -257,7 +282,9 @@
             "type": "generated",
             "help_text": "The webhook secret set in GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -265,7 +292,9 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabGroup",
@@ -273,7 +302,9 @@
             "type": "text",
             "help_text": "(Optional) Set to lock the plugin to a single GitLab group.",
             "placeholder": "groupName",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnablePrivateRepo",
@@ -281,9 +312,12 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to work with private repositories.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -343,7 +377,9 @@
             "type": "text",
             "help_text": "The base URL for using the plugin with a GitLab installation. Examples: https://gitlab.com or https://gitlab.example.com",
             "placeholder": "https://gitlab.com",
-            "default": "https://gitlab.com"
+            "default": "https://gitlab.com",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabOAuthClientID",
@@ -351,7 +387,9 @@
             "type": "text",
             "help_text": "The client ID for the OAuth app registered with GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabOAuthClientSecret",
@@ -359,7 +397,9 @@
             "type": "text",
             "help_text": "The client secret for the OAuth app registered with GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -367,7 +407,9 @@
             "type": "generated",
             "help_text": "The webhook secret set in GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -375,7 +417,9 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabGroup",
@@ -383,7 +427,9 @@
             "type": "text",
             "help_text": "(Optional) Set to lock the plugin to a single GitLab group.",
             "placeholder": "groupName",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnablePrivateRepo",
@@ -391,9 +437,12 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to work with private repositories.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -450,7 +499,9 @@
             "type": "text",
             "help_text": "The base URL for using the plugin with a GitLab installation. Examples: https://gitlab.com or https://gitlab.example.com",
             "placeholder": "https://gitlab.com",
-            "default": "https://gitlab.com"
+            "default": "https://gitlab.com",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabOAuthClientID",
@@ -458,7 +509,9 @@
             "type": "text",
             "help_text": "The client ID for the OAuth app registered with GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabOAuthClientSecret",
@@ -466,7 +519,9 @@
             "type": "text",
             "help_text": "The client secret for the OAuth app registered with GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -474,7 +529,9 @@
             "type": "generated",
             "help_text": "The webhook secret set in GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -482,7 +539,9 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabGroup",
@@ -490,7 +549,9 @@
             "type": "text",
             "help_text": "(Optional) Set to lock the plugin to a single GitLab group.",
             "placeholder": "groupName",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnablePrivateRepo",
@@ -498,9 +559,12 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to work with private repositories.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -557,7 +621,9 @@
             "type": "text",
             "help_text": "The base URL for using the plugin with a GitLab installation. Examples: https://gitlab.com or https://gitlab.example.com",
             "placeholder": "https://gitlab.com",
-            "default": "https://gitlab.com"
+            "default": "https://gitlab.com",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabOAuthClientID",
@@ -565,7 +631,9 @@
             "type": "text",
             "help_text": "The client ID for the OAuth app registered with GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabOAuthClientSecret",
@@ -573,7 +641,9 @@
             "type": "text",
             "help_text": "The client secret for the OAuth app registered with GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -581,7 +651,9 @@
             "type": "generated",
             "help_text": "The webhook secret set in GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -589,7 +661,9 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabGroup",
@@ -597,7 +671,9 @@
             "type": "text",
             "help_text": "(Optional) Set to lock the plugin to a single GitLab group.",
             "placeholder": "groupName",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnablePrivateRepo",
@@ -605,9 +681,12 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to work with private repositories.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -664,7 +743,9 @@
             "type": "text",
             "help_text": "The base URL for using the plugin with a GitLab installation. Examples: https://gitlab.com or https://gitlab.example.com",
             "placeholder": "https://gitlab.com",
-            "default": "https://gitlab.com"
+            "default": "https://gitlab.com",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabOAuthClientID",
@@ -672,7 +753,9 @@
             "type": "text",
             "help_text": "The client ID for the OAuth app registered with GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabOAuthClientSecret",
@@ -680,7 +763,9 @@
             "type": "text",
             "help_text": "The client secret for the OAuth app registered with GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -688,7 +773,9 @@
             "type": "generated",
             "help_text": "The webhook secret set in GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -696,7 +783,9 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabGroup",
@@ -704,7 +793,9 @@
             "type": "text",
             "help_text": "(Optional) Set to lock the plugin to a single GitLab group.",
             "placeholder": "groupName",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnablePrivateRepo",
@@ -712,9 +803,12 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to work with private repositories.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -762,7 +856,9 @@
             "type": "text",
             "help_text": "The base URL for using the plugin with a GitLab installation. Examples: https://gitlab.com or https://gitlab.example.com",
             "placeholder": "https://gitlab.com",
-            "default": "https://gitlab.com"
+            "default": "https://gitlab.com",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabOAuthClientID",
@@ -770,7 +866,9 @@
             "type": "text",
             "help_text": "The client ID for the OAuth app registered with GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabOAuthClientSecret",
@@ -778,7 +876,9 @@
             "type": "text",
             "help_text": "The client secret for the OAuth app registered with GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -786,7 +886,9 @@
             "type": "generated",
             "help_text": "The webhook secret set in GitLab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -794,7 +896,9 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabGroup",
@@ -802,7 +906,9 @@
             "type": "text",
             "help_text": "(Optional) Set to lock the plugin to a single GitLab group.",
             "placeholder": "groupName",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnablePrivateRepo",
@@ -810,9 +916,12 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to work with private repositories.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -859,7 +968,9 @@
             "type": "text",
             "help_text": "The client ID for the OAuth app registered with Gitlab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabOAuthClientSecret",
@@ -867,7 +978,9 @@
             "type": "text",
             "help_text": "The client secret for the OAuth app registered with Gitlab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -875,7 +988,9 @@
             "type": "generated",
             "help_text": "The webhook secret set in Gitlab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Username",
@@ -883,7 +998,9 @@
             "type": "username",
             "help_text": "Select the username of the user that the plugin will post with. This can be any user, the name and icon will be overridden when posting.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -891,7 +1008,9 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabGroup",
@@ -899,7 +1018,9 @@
             "type": "text",
             "help_text": "(Optional) Set to lock the plugin to a single Gitlab group.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnterpriseBaseURL",
@@ -907,7 +1028,9 @@
             "type": "text",
             "help_text": "(Optional) The base URL for using the plugin with a Gitlab Enterprise installation. Example: https://gitlab.example.com",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnablePrivateRepo",
@@ -915,9 +1038,12 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to work with private repositories.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -964,7 +1090,9 @@
             "type": "text",
             "help_text": "The client ID for the OAuth app registered with Gitlab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabOAuthClientSecret",
@@ -972,7 +1100,9 @@
             "type": "text",
             "help_text": "The client secret for the OAuth app registered with Gitlab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -980,7 +1110,9 @@
             "type": "generated",
             "help_text": "The webhook secret set in Gitlab.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Username",
@@ -988,7 +1120,9 @@
             "type": "username",
             "help_text": "Select the username of the user that the plugin will post with. This can be any user, the name and icon will be overridden when posting.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -996,7 +1130,9 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitlabGroup",
@@ -1004,7 +1140,9 @@
             "type": "text",
             "help_text": "(Optional) Set to lock the plugin to a single Gitlab group.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnterpriseBaseURL",
@@ -1012,7 +1150,9 @@
             "type": "text",
             "help_text": "(Optional) The base URL for using the plugin with a Gitlab Enterprise installation. Example: https://gitlab.example.com",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnablePrivateRepo",
@@ -1020,9 +1160,12 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to work with private repositories. Enabling private repositories will require existing users to reconnect their accounts to gain access to private repositories. A message will be automatically be sent to affected users next time they load Mattermost alerting them of this.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -1072,7 +1215,9 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing CircleCI integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -1080,9 +1225,12 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens. Regenerating the key will log out every user of their CircleCI account.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -1143,7 +1291,9 @@
             "type": "text",
             "help_text": "Trigger Word must be unique, and cannot begin with a slash or contain any spaces.",
             "placeholder": "",
-            "default": "poll"
+            "default": "poll",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ExperimentalUI",
@@ -1151,9 +1301,12 @@
             "type": "bool",
             "help_text": "When true, Matterpoll will render poll posts with a rich UI. The rich UI is not available on mobile app.",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -1204,7 +1357,8 @@
       "settings_schema": {
         "header": "",
         "footer": "* To report an issue, make a suggestion or a contribution, [check the GitHub repository]i(https://github.com/moussetc/mattermost-plugin-dice-roller/)",
-        "settings": []
+        "settings": [],
+        "sections": null
       }
     },
     "platforms": {
@@ -1272,7 +1426,9 @@
                 "display_name": "Collapsable image preview (the full URL is displayed, requires links preview to be activated)",
                 "value": "full_url"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Provider",
@@ -1294,7 +1450,9 @@
                 "display_name": "Tenor (API Key required below)",
                 "value": "tenor"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APIKey",
@@ -1302,7 +1460,9 @@
             "type": "text",
             "help_text": "Configure your own API Key (not required for Gfycat). To get your own API key, follow [these instructions for Giphy](https://developers.giphy.com/docs/api#quick-start-guide) or [these for Tenor](https://tenor.com/developer/keyregistration).",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Rating",
@@ -1328,7 +1488,9 @@
                 "display_name": "R",
                 "value": "r"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "RenditionGfycat",
@@ -1358,7 +1520,9 @@
                 "display_name": "Static preview image",
                 "value": "posterUrl"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Rendition",
@@ -1424,7 +1588,9 @@
                 "display_name": "Duration set to loop for 15 seconds. Only recommended for this exact use case.",
                 "value": "looping"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "RenditionTenor",
@@ -1446,7 +1612,9 @@
                 "display_name": "Tiny: reduced size of the original format, up to 220 pixels wide, good for mobile",
                 "value": "tinygif"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Language (GIPHY&Tenor only)",
@@ -1584,7 +1752,9 @@
                 "display_name": "Українська",
                 "value": "uk"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "DisablePostingWithoutPreview",
@@ -1592,9 +1762,12 @@
             "type": "bool",
             "help_text": "If deactivated, both /gif (no preview before posting) and /gifs (preview) will be available. This option is activated by default to prevent the accidental posting of inappropriate GIFs from a provider that does not allow content rating.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -1666,7 +1839,9 @@
                 "display_name": "Tenor (API Key required below)",
                 "value": "tenor"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APIKey",
@@ -1674,7 +1849,9 @@
             "type": "text",
             "help_text": "Configure your own API Key (not required for Gfycat). To get your own API key, follow [these instructions for Giphy](https://developers.giphy.com/docs/api#quick-start-guide) or [these for Tenor](https://tenor.com/developer/keyregistration).",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Rating",
@@ -1700,7 +1877,9 @@
                 "display_name": "R",
                 "value": "r"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "RenditionGfycat",
@@ -1730,7 +1909,9 @@
                 "display_name": "Static preview image",
                 "value": "posterUrl"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Rendition",
@@ -1796,7 +1977,9 @@
                 "display_name": "Duration set to loop for 15 seconds. Only recommended for this exact use case.",
                 "value": "looping"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "RenditionTenor",
@@ -1818,7 +2001,9 @@
                 "display_name": "Tiny: reduced size of the original format, up to 220 pixels wide, good for mobile",
                 "value": "tinygif"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Language (GIPHY&Tenor only)",
@@ -1956,9 +2141,12 @@
                 "display_name": "Українська",
                 "value": "uk"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -2019,7 +2207,9 @@
             "type": "text",
             "help_text": "",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "DOAdmins",
@@ -2027,7 +2217,9 @@
             "type": "text",
             "help_text": "Users that are not system admins on Mattermost but have advanced plugin privileges",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "IMAPServer",
@@ -2035,7 +2227,9 @@
             "type": "text",
             "help_text": "Enable imap on your email provider. Example of Google's imap server is 'imap.gmail.com:993'. 933 is usually the default port",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "IMAPUsername",
@@ -2043,7 +2237,9 @@
             "type": "text",
             "help_text": "This is the same as your Digital Ocean alerts email. Usually the email address. Something like example@gmail.com.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "IMAPPassword",
@@ -2051,7 +2247,9 @@
             "type": "text",
             "help_text": "",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "CronConfig",
@@ -2081,9 +2279,12 @@
                 "display_name": "Every 1 hour",
                 "value": "*/60 * * * *"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -2136,7 +2337,8 @@
       "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": []
+        "settings": [],
+        "sections": null
       }
     },
     "platforms": {
@@ -2194,7 +2396,9 @@
             "type": "text",
             "help_text": "The channel to send notifications to, specified in the format `teamname,channelname`. If the specified channel does not exist, the plugin will create the channel for you.\n \n Note: Must be the team and channel handle used in the URL. For example, in the following URL, set the value to `myteam,mychannel`: https://example.com/myteam/channels/mychannel.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "AllowedUserIds",
@@ -2202,7 +2406,9 @@
             "type": "text",
             "help_text": "List of users authorized to accept AWS SNS subscriptions to a Mattermost channel. Must be a comma-separated list of user IDs.\n \n Tip: Use the [mattermost user search](https://mattermost.com/pl/cli-mattermost-user-search) CLI command to determine a user ID.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Token",
@@ -2210,9 +2416,12 @@
             "type": "generated",
             "help_text": "Generated token to validate incoming requests from AWS SNS.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -2269,7 +2478,9 @@
             "type": "text",
             "help_text": "The channel to send notifications to, specified in the format `teamname,channelname`. If the specified channel does not exist, the plugin will create the channel for you.\n \nNote: Must be the team and channel handle used in the URL. For example, in the following URL, set the value to `myteam,mychannel`: https://example.com/myteam/channels/mychannel",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "AllowedUserIds",
@@ -2277,7 +2488,9 @@
             "type": "text",
             "help_text": "List of users authorized to accept AWS SNS subscriptions to a Mattermost channel. Must be a comma-separated list of user ID's.\n \nTip: Use the [mattermost user search](https://mattermost.com/pl/cli-mattermost-user-search) CLI command to determine a user ID.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Token",
@@ -2285,9 +2498,12 @@
             "type": "generated",
             "help_text": "Generated token to validate incoming requests from AWS SNS.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -2331,7 +2547,9 @@
             "type": "text",
             "help_text": "The channel to send notifications to, specified in the format `teamname,channelname`. If the specified channel does not exist, the plugin will create the channel for you.\n \nNote: Must be the team and channel handle used in the URL. For example, in the following URL, set the value to `myteam,mychannel`: https://example.com/myteam/channels/mychannel",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "AllowedUserIds",
@@ -2339,7 +2557,9 @@
             "type": "text",
             "help_text": "List of users authorized to accept AWS SNS subscriptions to a Mattermost channel. Must be a comma-separated list of user ID's.\n \nTip: Use the [mattermost user search](https://mattermost.com/pl/cli-mattermost-user-search) CLI command to determine a user ID.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Username",
@@ -2347,7 +2567,9 @@
             "type": "username",
             "help_text": "Select the username that this integration is attached to.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Token",
@@ -2355,9 +2577,12 @@
             "type": "generated",
             "help_text": "Generated token to validate incoming requests from AWS SNS.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -2410,7 +2635,9 @@
             "type": "text",
             "help_text": "The channel to send notifications to, specified in the format `teamname,channelname`. If the specified channel does not exist, the plugin will create the channel for you.\n\nNote: Must be the team and channel handle used in the URL. For example, in the following URL, set the value to `myteam,mychannel`: https://example.com/myteam/channels/mychannel",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "AllowedUserIds",
@@ -2418,7 +2645,9 @@
             "type": "text",
             "help_text": "List of users authorized to accept AWS SNS subscriptions to a Mattermost channel. Must be a comma-separated list of user ID's.\n\nTip: Use the [mattermost user search](https://mattermost.com/pl/cli-mattermost-user-search) CLI command to determine a user ID.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Username",
@@ -2426,7 +2655,9 @@
             "type": "username",
             "help_text": "Select the username that this integration is attached to.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Token",
@@ -2434,9 +2665,12 @@
             "type": "generated",
             "help_text": "Generated token to validate incoming requests from AWS SNS.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -2489,9 +2723,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing confluence integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -2550,9 +2787,12 @@
             "type": "custom",
             "help_text": "",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -2611,9 +2851,12 @@
             "type": "custom",
             "help_text": "",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -2662,7 +2905,8 @@
       "settings_schema": {
         "header": "Configure this plugin directly in the config.json file. Learn more [in our documentation](https://github.com/mattermost/mattermost-plugin-custom-attributes/blob/master/README.md).\n\nTo report an issue, make a suggestion or a contribution, [check the plugin repository](https://github.com/mattermost/mattermost-plugin-custom-attributes).",
         "footer": "",
-        "settings": null
+        "settings": null,
+        "sections": null
       }
     },
     "platforms": {
@@ -2702,7 +2946,8 @@
       "settings_schema": {
         "header": "Configure this plugin directly in the config.json file. Learn more [in our documentation](https://github.com/mattermost/mattermost-plugin-custom-attributes/blob/master/README.md).\n\nTo report an issue, make a suggestion or a contribution, [check the plugin repository](https://github.com/mattermost/mattermost-plugin-custom-attributes).",
         "footer": "",
-        "settings": null
+        "settings": null,
+        "sections": null
       }
     },
     "platforms": {
@@ -2751,7 +2996,8 @@
       "settings_schema": {
         "header": "Configure this plugin directly in the config.json file. Learn more [in our documentation](https://github.com/mattermost/mattermost-plugin-custom-attributes/blob/master/README.md).\n\nTo report an issue, make a suggestion or a contribution, [check the plugin repository](https://github.com/mattermost/mattermost-plugin-custom-attributes).",
         "footer": "",
-        "settings": null
+        "settings": null,
+        "sections": null
       }
     },
     "platforms": {
@@ -2791,7 +3037,8 @@
       "settings_schema": {
         "header": "Configure this plugin directly in the config.json file. Learn more [in our documentation](https://github.com/mattermost/mattermost-plugin-custom-attributes/blob/master/README.md).\n\nTo report an issue, make a suggestion or a contribution, [check the plugin repository](https://github.com/mattermost/mattermost-plugin-custom-attributes).",
         "footer": "",
-        "settings": null
+        "settings": null,
+        "sections": null
       }
     },
     "platforms": {
@@ -2841,7 +3088,9 @@
             "type": "text",
             "help_text": "List of users authorized to administer the plugin in addition to the System Admins. Must be a comma-separated list of user IDs.\n \nUser IDs can be found by navigating to **System Console** > **User Management**. After clicking into a user's name, their ID is on the right-hand side of the blue header.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "AdminLogLevel",
@@ -2871,7 +3120,9 @@
                 "display_name": "Error",
                 "value": "error"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "AdminLogVerbose",
@@ -2879,7 +3130,9 @@
             "type": "bool",
             "help_text": "",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "OAuth2Authority",
@@ -2887,7 +3140,9 @@
             "type": "text",
             "help_text": "Directory (tenant) ID",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "OAuth2ClientId",
@@ -2895,7 +3150,9 @@
             "type": "text",
             "help_text": "Microsoft Office Client ID.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "OAuth2ClientSecret",
@@ -2903,9 +3160,12 @@
             "type": "text",
             "help_text": "Microsoft Office Client Secret.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -2966,7 +3226,9 @@
             "type": "text",
             "help_text": "Copy the **Directory (tenant) ID** value from the App Overview Page in the Azure Portal.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "OAuth2ClientId",
@@ -2974,7 +3236,9 @@
             "type": "text",
             "help_text": "Copy the **Application (client) ID** value from the App Overview Page in the Azure Portal.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "OAuth2ClientSecret",
@@ -2982,9 +3246,12 @@
             "type": "text",
             "help_text": "Copy the **Client Secret** value (not ID) that was created on the App's **Certificates and Secrets** tab",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -3045,7 +3312,9 @@
             "type": "text",
             "help_text": "Directory (tenant) ID",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "OAuth2ClientId",
@@ -3053,7 +3322,9 @@
             "type": "text",
             "help_text": "Microsoft Office Client ID.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "OAuth2ClientSecret",
@@ -3061,9 +3332,12 @@
             "type": "text",
             "help_text": "Microsoft Office Client Secret.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -3123,9 +3397,12 @@
             "type": "bool",
             "help_text": "When true, a [user satisfaction survey](!https://mattermost.com/pl/default-nps) will be sent to all users quarterly. The survey results will be used by Mattermost, Inc. to improve the quality and user experience of the product. Please refer to our [privacy policy](!https://about.mattermost.com/default-privacy-policy) for more information on the collection and use of information received through our services.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -3185,9 +3462,12 @@
             "type": "bool",
             "help_text": "When true, a [user satisfaction survey](!https://mattermost.com/pl/default-nps) will be sent to all users quarterly. The survey results will be used by Mattermost, Inc. to improve the quality and user experience of the product. Please refer to our [privacy policy](!https://about.mattermost.com/default-privacy-policy) for more information on the collection and use of information received through our services.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -3244,9 +3524,12 @@
             "type": "bool",
             "help_text": "When true, a [user satisfaction survey](!https://mattermost.com/pl/default-nps) will be sent to all users quarterly. The survey results will be used by Mattermost, Inc. to improve the quality and user experience of the product. Please refer to our [privacy policy](!https://about.mattermost.com/default-privacy-policy) for more information on the collection and use of information received through our services.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -3303,9 +3586,12 @@
             "type": "bool",
             "help_text": "When true, a [net promoter score survey](!https://mattermost.com/pl/default-nps) will be sent to all users quarterly. The survey results will be used by Mattermost, Inc. to improve the quality and user experience of the product. Please refer to our [privacy policy](!https://mattermost.com/pl/default-nps-privacy-policy) for more information on the collection and use of information received through our services.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -3353,9 +3639,12 @@
             "type": "bool",
             "help_text": "When true, a [net promoter score survey](!https://mattermost.com/pl/default-nps) will be sent to all users quarterly. The survey results will be used by Mattermost, Inc. to improve the quality and user experience of the product. Please refer to our [privacy policy](!https://mattermost.com/pl/default-nps-privacy-policy) for more information on the collection and use of information received through our services.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -3403,9 +3692,12 @@
             "type": "bool",
             "help_text": "When true, a [net promoter score survey](!https://mattermost.com/pl/default-nps) will be sent to all users quarterly. The survey results will be used by Mattermost, Inc. to improve the quality and user experience of the product. Please refer to our [privacy policy](!https://mattermost.com/pl/default-nps-privacy-policy) for more information on the collection and use of information received through our services.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -3416,27 +3708,31 @@
     "updated_at": "2019-06-12T19:04:44Z"
   },
   {
-    "homepage_url": "",
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-channel-export/",
     "icon_data": "",
-    "download_url": "https://plugins.releases.mattermost.com/release/mattermost-plugin-channel-export-v0.2.2.tar.gz",
-    "release_notes_url": "",
+    "download_url": "https://plugins.releases.mattermost.com/release/mattermost-plugin-channel-export-v1.2.1.tar.gz",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-channel-export/releases/tag/v1.0.0",
     "hosting": "",
     "author_type": "mattermost",
     "release_stage": "production",
     "enterprise": true,
-    "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAl8qv9EACgkQ0bVLR6XO/sQ2thAAhKHvWx9qifDVZKOdG8c7lA74t6mCeQK7QMDCyynXnfjKlQxU3gQWNiNa99KCyn5g5RNbMphhW6mi0Koo9DCMuwk9V+eWXzcxjkaEPKq1Pjw+/tsniXfBbD5iIOTzd5s3CfyN9kEXA7Wi4pq4X9RggsPPgRCzO4oC1X4gim8bn4OwEZT26l5ALILJI0wheWapI/E2LqiPAXLUhsy3aMfnx+swpy0BgE4zef5eA34RdnmpEGfGhKHVylYhanbHbadO7Mv4auGUyqgXI41nZL/GyqnqMVklv+suLWlCMxRyLMSR+l4DvLJth2OiIwmGuGnXQqQJggW13HsZaJHwIU/yIXc9J4pn2YOpRM7FZ+nP1WxfpNdg2vwLdvmf+LbBgwFeo9Xh8vmZ1uoSERYG9Q0g7DcJDz8hvcvYivJDFfpNq8TYskZ21F9u/SBRD/jkXLNIkJ2MwESQxt5MuVXVEEeI44RHN2dqIEoxe5ufDmZcUAlmb3SC2cZHObrJPt8YGo5WO+oViRSD9Ii2JnNg0DsjyZ7Yz8YlyfgOusRX+GuI68KddQ6WUZGA0OES8c44TEr7VSCY0xMlMFLtg8u4ZTFTe6JxfrspSxjB3e2mSjfo4czzO21a40Of4eUa+TDh7oI6h7FaSmO8qj10HOmJSJpWsPHpkuQvUXIjA7+S6ieSrjU=",
+    "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmdiPMkACgkQ0bVLR6XO/sRsBRAAjX1gMrbRqqexAt897l5mRnEuHTZcI51t9rM6qWhXvLSdmZEZv53gANyypi5IGUoHMizS/3PvFuKOXtDMTvmhTd2uZF57UjwasEF5dDNgKTUcZeRGEiDMWkta5rqVmg6g2ZJMhrG6ux0ZS2gnOVr7P2JMYAr0sdeSjFxzFD6iFiYy1BVZiKfYY0wUWlX6t0dHC15P3TgSMHJTsRuKdFVbt7mjfjjTCifgF+I0LLcQVpAvelLjTvCxdy8XSSNx8VJGIMVfUFO+fcsYZx7Z82cmgaaLrhtiO+ScGG0GeekMgo9hXxyiY6tIBGrRBs6+JiuAR/8gEVoGp6YBvncEqq/xtVHa9m6sQOgvFnP3Ip9u04Qrmnd29IniWp36X0eDUGiT6JA4VZr5cnB5Zdsh9NoFGhGXEeUsMQpXKpfwjQ0gAbZAwbOmCLMeRebW24zVDVjDTkFuTlJchAOqgVzFXQxUgjRL3YIuK+qo35N6Qj7A7zSl90I3X98M/iMKFFbFZ2y6YC5J7TC/KRbTXmNQAZLFnR7/NwbPnI9zMNhZk3Tqhm8WSXBFJiAdfty330ewmnCPpNTwG7ttZ3DEiBPoLFV9nvjajhYxaTveOKoNzA5atHmH82Pw6fsq8/7y30TcE+N8k5C37RYn93nvdrZPULj7xrK1rXy6XFnRZszaFS9sOgE=",
     "repo_name": "mattermost-plugin-channel-export",
     "manifest": {
       "id": "com.mattermost.plugin-channel-export",
       "name": "Channel Export",
       "description": "This plugin allows channel export into a human readable format.",
-      "version": "0.2.2",
-      "min_server_version": "5.12.0",
+      "homepage_url": "https://github.com/mattermost/mattermost-plugin-channel-export/",
+      "support_url": "https://github.com/mattermost/mattermost-plugin-channel-export/issues",
+      "release_notes_url": "https://github.com/mattermost/mattermost-plugin-channel-export/releases/tag/v1.2.1",
+      "version": "1.2.1",
+      "min_server_version": "5.37.0",
       "server": {
         "executables": {
           "darwin-amd64": "server/dist/plugin-darwin-amd64",
+          "darwin-arm64": "server/dist/plugin-darwin-arm64",
           "linux-amd64": "server/dist/plugin-linux-amd64",
-          "windows-amd64": "server/dist/plugin-windows-amd64.exe"
+          "linux-arm64": "server/dist/plugin-linux-arm64"
         },
         "executable": ""
       },
@@ -3446,24 +3742,43 @@
       "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": []
+        "settings": [
+          {
+            "key": "EnableAdminRestrictions",
+            "display_name": "Enable Admin Restrictions",
+            "type": "bool",
+            "help_text": "Restricts the exporting of channels to system administrators or channel administrators",
+            "placeholder": "",
+            "default": false,
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "MaxFileSize",
+            "display_name": "Maximum size of channel export file in bytes",
+            "type": "number",
+            "help_text": "Determines the maximum size of the channel export file when using the slash command. A value of 0 will use the [FileSettings.MaxFileSize](https://docs.mattermost.com/configure/environment-configuration-settings.html#maximum-file-size) from Mattermost server.",
+            "placeholder": "",
+            "default": 0,
+            "hosting": "",
+            "secret": false
+          }
+        ],
+        "sections": null
       }
     },
     "platforms": {
       "linux-amd64": {
-        "download_url": "https://plugins.releases.mattermost.com/release/mattermost-plugin-channel-export-v0.2.2-linux-amd64.tar.gz",
-        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAl8qv9AACgkQ0bVLR6XO/sSWqw/9GLwFOW4vWMVkVwZLZzzl0nLpkobdARD4rHiA+TjADF+xGihOD76uB2XUJIq0nFmXfWHb57HNunSWiBW0oGtlYfHHt8pbcjYSJVh31BHr367eGMpiad2xwy8l9hpdHW9JxoQFhrJgroeWHtj5G3LnGSxRyOWpR4WS/Gde5lH2yFoBrPEV8r1+ouaYjlfMhMnsxwCc9yqt+z5gxKrs3CGAfgnafLc0WnpE/3HTPBiRwJnWVWd0jafV/RvNbRZ1BDbWxhB9uI2jt/6C3UiTXkQ3hz9UMs2WjSZolqABRkvHtwmWk9jbZJkTDxwXyCxF1izU/x8Y5lxqvFh/KYOJy/ZyggGtQkaY97q0pOgBxeLibdKl6+XOixpF8yEfs0Wod3OA1GlPZSxUj0gcLwUSr+YgBethXGPt+CHjWj3RKYSuALFhzh430d3dvwRQmX4oRz+2D4SX+HZ3rhholgl6K6w2t2IEknWF70/LTAU+Pb1Qf2QgsPbAlAJU6+CyIJrILcUDs2UhRbUjRcjCHlp2vzXEBbPVqOvngidZvrQlByEF3BXB7hWoDU2xCwoUvaH2f5afk5sM3kPI9d/OhIV9XBWnqJu8EPzsddeWz3kZpAfWC58/ghXU62jfmfqR5dmX4iX0cPT2Qs2yZ2aPACl5TzBdRtPGJRRLdlDaDAt0n6p3isY="
+        "download_url": "https://plugins.releases.mattermost.com/release/mattermost-plugin-channel-export-v1.2.1-linux-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmdiPMgACgkQ0bVLR6XO/sQB7A/+MC1vTC0LD8Mr0SbPXHDqPH08jqs5pUxcF3DDG9zWq3Haesm3+bMA50bJKFIC/lfVzA3UPYEwRzxgo+g4Zb4wmm+ZdO27yH30jTWqOlx33nxQeq+UcgKFuDvH/B5rUHXpkG0evmSOSEgnsuvizIwJaup6BqktlQyx2hS5Q7nzMw2ZKBeGwv68T//l/evIsn7St0Y4ZbgTq1uHzRmfyWd4tzBlPsThBkPQx+HmI7y4dPBj4Dp7XAhiUv2F9nQnZrNAyNuDrYw7nVigF/BRJmpZRweChOMBJ+VI6E/D4Jx8IADu/72PoIlV4dGR3JeHYq7zKsT3RqrDsE2G4bjaZxQNrvvYJ8W3QpEHlLdspMe7l1bwcbDrz+JyC8Zi3ZsQIn+OamRQGVgDL4VLmu8YGgJbVYzKLDaAASh7StRsaP75iplF/IKMD2KLAmjCx1sCzZfwo30hIsDzwyY/PQk4ffA2coXCaC1XRTecG+HQxzhicg3v8ne4pcI13QJDl5p6Ov5zute7NIlE/nKy3NZou/x3BJm8xxsyy3CNvdCSdhBAWBc+l2eGgyXnw8nMSEgCgObmqFzN+OSqtwqFFV0UCN8T87Vrx3kzU/YW6EnGcJJ3Mb877V5RbamMpLe74fCK0xbRhQFovsUqv55pZR3obIm02FxZekM309F5d98NKQscYKg="
       },
-      "darwin-amd64": {
-        "download_url": "https://plugins.releases.mattermost.com/release/mattermost-plugin-channel-export-v0.2.2-osx-amd64.tar.gz",
-        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAl8qv80ACgkQ0bVLR6XO/sTLCg/+IAPPhpWge68vr4s/3V7/AttyJnfIj9JWwpcKUQ6kZQsE+Qscnrefok6yfXASEFKPnjzgQcs660ihvTZNX8PnxST0vkYO6+3WGc8J1LbKgLBVSSjL5jSSxeZHNjtP0rF8nUTBHEfaWwhwyCLsD4zllc4f9DA0aKKU384RX0feWT4i7ztjKy3kKC2jB2ZN/wWyLmJZs+rZEuTLyaOQiAslB9/FsOkYeK1Eii5vpAz3CkqzhBpYbO0hlO5vuS6Ug7lOS9qGMmOPCqS8VGP6YiUsQMZBC9QsXpRVSIqIqXxjDVP2x15t1OOF2iAKZcxCF6OxWvDmUwP5+VS6LfwP19tZzfqY92lKS/9YiKbQjC3s91tMoYpcg5XlRMhTR2oRBLLVom37oU64HPyNFQxiEqzNZzsR1H10Z9rvAgjYzDAf6V/irS+edDVIg7h7wPtD49paHBRFzjbuGYTz+MfAByu+7FogG0eaV60Nid89fZcoXQplB8zR8zeJnz1VEpsg//gGKzD40BMwtOvmEZxUECclmw8odopsSmE3b8lrH+WyyXyd+IS8wj7hJpz0A1DdS+WPyT4e2TVGwdQHK8bVKBdQ2JJhRoln9UiK9KE7q388AW/mBmyEW9kZ8lgMv/EGGp1EXpMsxIgJ15e0Cxi4NX9eRtUl2/ypiANVN//7KO4FoqY="
-      },
+      "darwin-amd64": {},
       "windows-amd64": {
-        "download_url": "https://plugins.releases.mattermost.com/release/mattermost-plugin-channel-export-v0.2.2-windows-amd64.tar.gz",
-        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAl8qv84ACgkQ0bVLR6XO/sTcaBAAhaV6LsrJDB7mov/NGrEJ+oZ1fzDhOsBd0nuYjxgMZaTBJ/wE97gZvVjc9Gg21pexz5CZW2kIOCqcGymUoNz3RLjRBs8Vz7ayl14YCnS0ZKu9AlRxa2C9h22v0gUEsFfYZMrEAQmE2gTNaXxG20pMD768/rDL1XVQuXcfCzFLEBQVS9XtNdwzwQZS6RazNZ//1R4e6a7yvs7wDYEeNqdfslH1qFKykOyLT65mJ2W+RnDYCy414cV8nuV98QbEqVMtjZZ95VItJoeUg3VLRIEvAZTfkW8xWbvsdYlHid+PcJ5vhJPoL79MIzQ/mXOXGbWCUgY9l5q5Gxkco5l/+jbrrDUfKtM97g9gxq/ecn7Why/G1/6Z5cZvPGj/8AYgSZFD7Fvpx607gq7mhxw6OpImfSi+QJUo3t6nhKDTVMvgIvwoX6kL/5lKxz5IdIpcATr2v77+WFAJR5tqR9L32PQ5nXhXq2LoRQYiMZ1AylC+kQ0VGH8ojXqBWjddgqOBrRSyR/gecyp41dUPFYifwo+cuGRHvkkIOYqeg6awN0LuwXwj8LzMj4GbnlvVPHoNoNMgljAsD94AWbSwZofZ4oBQCIMDStcORszZXkyh3eGJKYBDHz/5cgCisei245Jg8N60OaWMBlSKhgBwj4EVWextmN1e65umildDQtGECi2OPjA="
+        "download_url": "https://plugins.releases.mattermost.com/release/mattermost-plugin-channel-export-v1.2.1-windows-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmdiPMkACgkQ0bVLR6XO/sR/5A/+Jt58X8xcxoB/ASX4pTPtDcSFOUQNxp+1J9F4lXkA16D+c38jXmgh2fh3NfHT5vdZxf3wl7YdHJFyRE3C1+xyx7C2FIXpw8585hoHVcBS9fe5GhPiWL4DdbAUp0UClUOhDPDaeshygqt5OzmrQesoJdjJhF+6ZWsDMy9N1DRrk31QPEPta7W0j6tRdIEt1NASbe36DhRN9kiVA6zhs3+x4K+mawCCgjlhYWbuQpmD7gaqSb7mMlOXJ2Ty1b8PROeZZGdi6gwvDT86/VB60y84M9TYKkdgT6lfiax+HcAg11t0ht6Kv03nhWiHTNEuZAYvyhvsJ16lS+cVgIne8PkzDn6GcWL7AY560+/7dtAQoCVpZENxQQeF9GHGbso2HJOlXcBOU1J2B7oUfjZtyUoBfPx5ZceVgFQc9GHO3U2IBAo4pK2H8fuhLroACZvwsJG3rGJ0Un6xO1OUl0eSTgfbtx1UB15/HBivwyPRDB1ihZFoQV9BwQiVXw6SIxsBdgiukTglabVEEagsPeZ2x+n0qE27GcZl83W0uBcXBOpDZreE7wqCqlv2ydMMv9E0Pu9fybmEvtZWvjwtxG8Guv8FICtyyR+RJNb02DnjtaelAYC6xZRUgiObyQP4IPpRUCHq+6WEGBzG50MzDB5BEAQX3vUWpHBLOWL03TRJyPt+NB8="
       }
     },
-    "updated_at": "2020-11-24T20:45:34.9149195Z"
+    "updated_at": "2025-01-08T20:58:41.256857158Z"
   },
   {
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-incident-collaboration/",
@@ -3515,9 +3830,12 @@
             "type": "custom",
             "help_text": "",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -3571,7 +3889,8 @@
       "settings_schema": {
         "header": "Incident Collaboration requires a Mattermost Cloud or Mattermost E20 License.",
         "footer": "",
-        "settings": []
+        "settings": [],
+        "sections": null
       }
     },
     "platforms": {
@@ -3625,7 +3944,8 @@
       "settings_schema": {
         "header": "Incident Collaboration requires a Mattermost Cloud or Mattermost E20 License.",
         "footer": "",
-        "settings": []
+        "settings": [],
+        "sections": null
       }
     },
     "platforms": {
@@ -3679,7 +3999,8 @@
       "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": []
+        "settings": [],
+        "sections": null
       }
     },
     "platforms": {
@@ -3733,7 +4054,8 @@
       "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": []
+        "settings": [],
+        "sections": null
       }
     },
     "platforms": {
@@ -3787,7 +4109,8 @@
       "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": []
+        "settings": [],
+        "sections": null
       }
     },
     "platforms": {
@@ -3841,7 +4164,8 @@
       "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": []
+        "settings": [],
+        "sections": null
       }
     },
     "platforms": {
@@ -3895,7 +4219,8 @@
       "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": []
+        "settings": [],
+        "sections": null
       }
     },
     "platforms": {
@@ -3949,7 +4274,8 @@
       "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": []
+        "settings": [],
+        "sections": null
       }
     },
     "platforms": {
@@ -4003,7 +4329,8 @@
       "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": []
+        "settings": [],
+        "sections": null
       }
     },
     "platforms": {
@@ -4057,7 +4384,8 @@
       "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": []
+        "settings": [],
+        "sections": null
       }
     },
     "platforms": {
@@ -4117,9 +4445,12 @@
             "type": "bool",
             "help_text": "When true, the buttons in the team sidebar on the left toolbar will be hidden.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -4171,7 +4502,8 @@
       "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": []
+        "settings": [],
+        "sections": null
       }
     },
     "platforms": {
@@ -4221,7 +4553,8 @@
       "settings_schema": {
         "header": "",
         "footer": "",
-        "settings": []
+        "settings": [],
+        "sections": null
       }
     },
     "platforms": {
@@ -4282,9 +4615,12 @@
             "type": "text",
             "help_text": "The hostname for your team's Webex site. For example: teamsite.webex.com",
             "placeholder": "teamsite.webex.com",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -4341,9 +4677,12 @@
             "type": "text",
             "help_text": "The hostname for your team's Webex site. For example: teamsite.webex.com",
             "placeholder": "teamsite.webex.com",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -4391,9 +4730,12 @@
             "type": "text",
             "help_text": "The hostname for your team's Webex site. For example: teamsite.webex.com",
             "placeholder": "teamsite.webex.com",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -4433,7 +4775,8 @@
       "settings_schema": {
         "header": "Configure this plugin directly in the config.json file. Learn more [in our documentation](https://github.com/mattermost/mattermost-plugin-welcomebot/blob/master/README.md).\n\nTo report an issue, make a suggestion or a contribution, [check the plugin repository](https://github.com/mattermost/mattermost-plugin-welcomebot)",
         "footer": "",
-        "settings": null
+        "settings": null,
+        "sections": null
       }
     },
     "platforms": {
@@ -4480,7 +4823,8 @@
       "settings_schema": {
         "header": "Configure this plugin directly in the config.json file. Learn more [in our documentation](https://github.com/mattermost/mattermost-plugin-welcomebot/blob/master/README.md).\n\nTo report an issue, make a suggestion or a contribution, [check the plugin repository](https://github.com/mattermost/mattermost-plugin-welcomebot)",
         "footer": "",
-        "settings": null
+        "settings": null,
+        "sections": null
       }
     },
     "platforms": {
@@ -4527,7 +4871,8 @@
       "settings_schema": {
         "header": "Configure this plugin directly in the config.json file. Learn more [in our documentation](https://github.com/mattermost/mattermost-plugin-welcomebot/blob/master/README.md).\n\nTo report an issue, make a suggestion or a contribution, [check the plugin repository](https://github.com/mattermost/mattermost-plugin-welcomebot)",
         "footer": "",
-        "settings": null
+        "settings": null,
+        "sections": null
       }
     },
     "platforms": {
@@ -4565,7 +4910,8 @@
       "settings_schema": {
         "header": "Configure this plugin directly in the config.json file. Learn more [in our documentation](https://github.com/mattermost/mattermost-plugin-welcomebot/blob/master/README.md).\n\nTo report an issue, make a suggestion or a contribution, [check the plugin repository](https://github.com/mattermost/mattermost-plugin-welcomebot)",
         "footer": "",
-        "settings": null
+        "settings": null,
+        "sections": null
       }
     },
     "platforms": {
@@ -4662,7 +5008,9 @@
             "type": "text",
             "help_text": "The client ID for the OAuth app registered with GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitHubOAuthClientSecret",
@@ -4670,7 +5018,9 @@
             "type": "text",
             "help_text": "The client secret for the OAuth app registered with GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -4678,7 +5028,9 @@
             "type": "generated",
             "help_text": "The webhook secret set in GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -4686,7 +5038,9 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GithubOrg",
@@ -4694,7 +5048,9 @@
             "type": "text",
             "help_text": "(Optional) Set to lock the plugin to a single GitHub organization.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnterpriseBaseURL",
@@ -4702,7 +5058,9 @@
             "type": "text",
             "help_text": "(Optional) The base URL for using the plugin with a GitHub Enterprise installation. Example: https://github.example.com",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnterpriseUploadURL",
@@ -4710,7 +5068,9 @@
             "type": "text",
             "help_text": "(Optional) The upload URL for using the plugin with a GitHub Enterprise installation. This is often the same as your Base URL.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnablePrivateRepo",
@@ -4718,7 +5078,9 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to work with private repositories. When enabled, existing users must reconnect their accounts to gain access to private repositories. Affected users will be notified by the plugin once private repositories are enabled.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnableCodePreview",
@@ -4740,9 +5102,12 @@
                 "display_name": "Disable",
                 "value": "disable"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -4803,7 +5168,9 @@
             "type": "text",
             "help_text": "The client ID for the OAuth app registered with GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitHubOAuthClientSecret",
@@ -4811,7 +5178,9 @@
             "type": "text",
             "help_text": "The client secret for the OAuth app registered with GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -4819,7 +5188,9 @@
             "type": "generated",
             "help_text": "The webhook secret set in GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -4827,7 +5198,9 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GithubOrg",
@@ -4835,7 +5208,9 @@
             "type": "text",
             "help_text": "(Optional) Set to lock the plugin to a single GitHub organization.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnterpriseBaseURL",
@@ -4843,7 +5218,9 @@
             "type": "text",
             "help_text": "(Optional) The base URL for using the plugin with a GitHub Enterprise installation. Example: https://github.example.com",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnterpriseUploadURL",
@@ -4851,7 +5228,9 @@
             "type": "text",
             "help_text": "(Optional) The upload URL for using the plugin with a GitHub Enterprise installation. This is often the same as your Base URL.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnablePrivateRepo",
@@ -4859,7 +5238,9 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to work with private repositories. When enabled, existing users must reconnect their accounts to gain access to private repositories. Affected users will be notified by the plugin once private repositories are enabled.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnableCodePreview",
@@ -4881,9 +5262,12 @@
                 "display_name": "Disable",
                 "value": "disable"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -4943,7 +5327,9 @@
             "type": "text",
             "help_text": "The client ID for the OAuth app registered with GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitHubOAuthClientSecret",
@@ -4951,7 +5337,9 @@
             "type": "text",
             "help_text": "The client secret for the OAuth app registered with GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -4959,7 +5347,9 @@
             "type": "generated",
             "help_text": "The webhook secret set in GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -4967,7 +5357,9 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GithubOrg",
@@ -4975,7 +5367,9 @@
             "type": "text",
             "help_text": "(Optional) Set to lock the plugin to a single GitHub organization.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnterpriseBaseURL",
@@ -4983,7 +5377,9 @@
             "type": "text",
             "help_text": "(Optional) The base URL for using the plugin with a GitHub Enterprise installation. Example: https://github.example.com",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnterpriseUploadURL",
@@ -4991,7 +5387,9 @@
             "type": "text",
             "help_text": "(Optional) The upload URL for using the plugin with a GitHub Enterprise installation. This is often the same as your Base URL.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnablePrivateRepo",
@@ -4999,7 +5397,9 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to work with private repositories. When enabled, existing users must reconnect their accounts to gain access to private repositories. Affected users will be notified by the plugin once private repositories are enabled.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnableCodePreview",
@@ -5007,9 +5407,12 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to expand permalinks to github files with an actual preview of the linked file.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -5069,7 +5472,9 @@
             "type": "text",
             "help_text": "The client ID for the OAuth app registered with GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitHubOAuthClientSecret",
@@ -5077,7 +5482,9 @@
             "type": "text",
             "help_text": "The client secret for the OAuth app registered with GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -5085,7 +5492,9 @@
             "type": "generated",
             "help_text": "The webhook secret set in GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -5093,7 +5502,9 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GithubOrg",
@@ -5101,7 +5512,9 @@
             "type": "text",
             "help_text": "(Optional) Set to lock the plugin to a single GitHub organization.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnterpriseBaseURL",
@@ -5109,7 +5522,9 @@
             "type": "text",
             "help_text": "(Optional) The base URL for using the plugin with a GitHub Enterprise installation. Example: https://github.example.com",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnterpriseUploadURL",
@@ -5117,7 +5532,9 @@
             "type": "text",
             "help_text": "(Optional) The upload URL for using the plugin with a GitHub Enterprise installation. This is often the same as your Base URL.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnablePrivateRepo",
@@ -5125,7 +5542,9 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to work with private repositories. When enabled, existing users must reconnect their accounts to gain access to private repositories. Affected users will be notified by the plugin once private repositories are enabled.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnableCodePreview",
@@ -5133,9 +5552,12 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to expand permalinks to github files with an actual preview of the linked file.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -5195,7 +5617,9 @@
             "type": "text",
             "help_text": "The client ID for the OAuth app registered with GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitHubOAuthClientSecret",
@@ -5203,7 +5627,9 @@
             "type": "text",
             "help_text": "The client secret for the OAuth app registered with GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -5211,7 +5637,9 @@
             "type": "generated",
             "help_text": "The webhook secret set in GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -5219,7 +5647,9 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GithubOrg",
@@ -5227,7 +5657,9 @@
             "type": "text",
             "help_text": "(Optional) Set to lock the plugin to a single GitHub organization.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnterpriseBaseURL",
@@ -5235,7 +5667,9 @@
             "type": "text",
             "help_text": "(Optional) The base URL for using the plugin with a GitHub Enterprise installation. Example: https://github.example.com",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnterpriseUploadURL",
@@ -5243,7 +5677,9 @@
             "type": "text",
             "help_text": "(Optional) The upload URL for using the plugin with a GitHub Enterprise installation. This is often the same as your Base URL.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnablePrivateRepo",
@@ -5251,7 +5687,9 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to work with private repositories. When enabled, existing users must reconnect their accounts to gain access to private repositories. Affected users will be notified by the plugin once private repositories are enabled.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnableCodePreview",
@@ -5259,9 +5697,12 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to expand permalinks to github files with an actual preview of the linked file.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -5312,7 +5753,9 @@
             "type": "text",
             "help_text": "The client ID for the OAuth app registered with GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitHubOAuthClientSecret",
@@ -5320,7 +5763,9 @@
             "type": "text",
             "help_text": "The client secret for the OAuth app registered with GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -5328,7 +5773,9 @@
             "type": "generated",
             "help_text": "The webhook secret set in GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -5336,7 +5783,9 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GithubOrg",
@@ -5344,7 +5793,9 @@
             "type": "text",
             "help_text": "(Optional) Set to lock the plugin to a single GitHub organization.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnterpriseBaseURL",
@@ -5352,7 +5803,9 @@
             "type": "text",
             "help_text": "(Optional) The base URL for using the plugin with a GitHub Enterprise installation. Example: https://github.example.com",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnterpriseUploadURL",
@@ -5360,7 +5813,9 @@
             "type": "text",
             "help_text": "(Optional) The upload URL for using the plugin with a GitHub Enterprise installation. This is often the same as your Base URL.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnablePrivateRepo",
@@ -5368,9 +5823,12 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to work with private repositories. When enabled, existing users must reconnect their accounts to gain access to private repositories. Affected users will be notified by the plugin once private repositories are enabled.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -5418,7 +5876,9 @@
             "type": "text",
             "help_text": "The client ID for the OAuth app registered with GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GitHubOAuthClientSecret",
@@ -5426,7 +5886,9 @@
             "type": "text",
             "help_text": "The client secret for the OAuth app registered with GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -5434,7 +5896,9 @@
             "type": "generated",
             "help_text": "The webhook secret set in GitHub.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -5442,7 +5906,9 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GithubOrg",
@@ -5450,7 +5916,9 @@
             "type": "text",
             "help_text": "(Optional) Set to lock the plugin to a single GitHub organization.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnterpriseBaseURL",
@@ -5458,7 +5926,9 @@
             "type": "text",
             "help_text": "(Optional) The base URL for using the plugin with a GitHub Enterprise installation. Example: https://github.example.com",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnterpriseUploadURL",
@@ -5466,7 +5936,9 @@
             "type": "text",
             "help_text": "(Optional) The upload URL for using the plugin with a GitHub Enterprise installation. This is often the same as your Base URL.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnablePrivateRepo",
@@ -5474,9 +5946,12 @@
             "type": "bool",
             "help_text": "(Optional) Allow the plugin to work with private repositories. When enabled, existing users must reconnect their accounts to gain access to private repositories. Affected users will be notified by the plugin once private repositories are enabled.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -5534,7 +6009,9 @@
             "type": "text",
             "help_text": "The URL for your Jenkins instance. Must start with http:// or https://. For example: https://jenkins.example.com.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -5542,9 +6019,12 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -5597,7 +6077,9 @@
             "type": "text",
             "help_text": "The URL for your Jenkins instance. Must start with http:// or https://. For example: https://jenkins.example.com.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -5605,9 +6087,12 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -5660,7 +6145,9 @@
             "type": "text",
             "help_text": "The URL for your Jenkins instance. Must start with http:// or https://. For example: https://jenkins.example.com.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Username",
@@ -5668,7 +6155,9 @@
             "type": "username",
             "help_text": "Select the username of the user that the plugin will post with. This can be any user, the name and icon will be overridden when posting.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -5676,9 +6165,12 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -5722,7 +6214,9 @@
             "type": "text",
             "help_text": "Specify the URL with the protocol. Either 'http' or 'https'.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Username",
@@ -5730,7 +6224,9 @@
             "type": "username",
             "help_text": "Select the username of the user that the plugin will post with. This can be any user, the name and icon will be overridden when posting.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -5738,9 +6234,12 @@
             "type": "generated",
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -5792,7 +6291,9 @@
             "type": "bool",
             "help_text": "When false, users cannot attach and create Jira issues in Mattermost. Does not affect Jira webhook notifications. After changing this setting to false, disable, then re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When true, install this plugin to your Jira instance with '/jira install’ to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Secret",
@@ -5801,7 +6302,9 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Jira integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "StatsSecret",
@@ -5810,7 +6313,9 @@
             "help_text": "The secret used to access plugin's stats API.",
             "regenerate_help_text": "Regenerates the secret for the stats API endpoint. Regenerating the secret invalidates your existing stats API clients.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "RolesAllowedToEditJiraSubscriptions",
@@ -5836,7 +6341,9 @@
                 "display_name": "System Admins",
                 "value": "system_admin"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GroupsAllowedToEditJiraSubscriptions",
@@ -5844,7 +6351,9 @@
             "type": "text",
             "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription. Jira groups restrictions are only applicable for a legacy instance installed on Jira 2.4 or earlier.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "JiraAdminAdditionalHelpText",
@@ -5852,7 +6361,9 @@
             "type": "text",
             "help_text": "Additional Help Text to be shown to the user along with the output of `/jira help` command",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "HideDecriptionComment",
@@ -5860,7 +6371,9 @@
             "type": "bool",
             "help_text": "Hide detailed issue descriptions and comments from Subscription and Webhook messages",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnableAutocomplete",
@@ -5868,9 +6381,12 @@
             "type": "bool",
             "help_text": "Autocomplete guides users through the available `/jira` slash commands",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -5931,7 +6447,9 @@
             "type": "bool",
             "help_text": "When false, users cannot attach and create Jira issues in Mattermost. Does not affect Jira webhook notifications. After changing this setting to false, disable, then re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When true, install this plugin to your Jira instance with '/jira install’ to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Secret",
@@ -5940,7 +6458,9 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Jira integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "StatsSecret",
@@ -5949,7 +6469,9 @@
             "help_text": "The secret used to access plugin's stats API.",
             "regenerate_help_text": "Regenerates the secret for the stats API endpoint. Regenerating the secret invalidates your existing stats API clients.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "RolesAllowedToEditJiraSubscriptions",
@@ -5975,7 +6497,9 @@
                 "display_name": "System Admins",
                 "value": "system_admin"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GroupsAllowedToEditJiraSubscriptions",
@@ -5983,7 +6507,9 @@
             "type": "text",
             "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription. Jira groups restrictions are only applicable for a legacy instance installed on Jira 2.4 or earlier.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "JiraAdminAdditionalHelpText",
@@ -5991,7 +6517,9 @@
             "type": "text",
             "help_text": "Additional Help Text to be shown to the user along with the output of `/jira help` command",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "HideDecriptionComment",
@@ -5999,7 +6527,9 @@
             "type": "bool",
             "help_text": "Hide detailed issue descriptions and comments from Subscription and Webhook messages",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnableAutocomplete",
@@ -6007,9 +6537,12 @@
             "type": "bool",
             "help_text": "Autocomplete guides users through the available `/jira` slash commands",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -6069,7 +6602,9 @@
             "type": "bool",
             "help_text": "When false, users cannot attach and create Jira issues in Mattermost. Does not affect Jira webhook notifications. After changing this setting to false, disable, then re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When true, install this plugin to your Jira instance with '/jira install’ to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Secret",
@@ -6078,7 +6613,9 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Jira integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "StatsSecret",
@@ -6087,7 +6624,9 @@
             "help_text": "The secret used to access plugin's stats API.",
             "regenerate_help_text": "Regenerates the secret for the stats API endpoint. Regenerating the secret invalidates your existing stats API clients.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "RolesAllowedToEditJiraSubscriptions",
@@ -6113,7 +6652,9 @@
                 "display_name": "System Admins",
                 "value": "system_admin"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GroupsAllowedToEditJiraSubscriptions",
@@ -6121,7 +6662,9 @@
             "type": "text",
             "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "JiraAdminAdditionalHelpText",
@@ -6129,7 +6672,9 @@
             "type": "text",
             "help_text": "Additional Help Text to be shown to the user along with the output of `/jira help` command",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "HideDecriptionComment",
@@ -6137,9 +6682,12 @@
             "type": "bool",
             "help_text": "Hide detailed issue descriptions and comments from Subscription and Webhook messages",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -6196,7 +6744,9 @@
             "type": "bool",
             "help_text": "When false, users cannot attach and create Jira issues in Mattermost. Does not affect Jira webhook notifications. After changing this setting to false, disable, then re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When true, install this plugin to your Jira instance with '/jira install’ to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Secret",
@@ -6205,7 +6755,9 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Jira integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "StatsSecret",
@@ -6214,7 +6766,9 @@
             "help_text": "The secret used to access plugin's stats API.",
             "regenerate_help_text": "Regenerates the secret for the stats API endpoint. Regenerating the secret invalidates your existing stats API clients.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "RolesAllowedToEditJiraSubscriptions",
@@ -6240,7 +6794,9 @@
                 "display_name": "System Admins",
                 "value": "system_admin"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GroupsAllowedToEditJiraSubscriptions",
@@ -6248,7 +6804,9 @@
             "type": "text",
             "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "JiraAdminAdditionalHelpText",
@@ -6256,9 +6814,12 @@
             "type": "text",
             "help_text": "Additional Help Text to be shown to the user along with the output of `/jira help` command",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -6315,7 +6876,9 @@
             "type": "bool",
             "help_text": "When false, users cannot attach and create Jira issues in Mattermost. Does not affect Jira webhook notifications. After changing this setting to false, disable, then re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When true, install this plugin to your Jira instance with '/jira install’ to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Secret",
@@ -6324,7 +6887,9 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Jira integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "StatsSecret",
@@ -6333,7 +6898,9 @@
             "help_text": "The secret used to access plugin's stats API.",
             "regenerate_help_text": "Regenerates the secret for the stats API endpoint. Regenerating the secret invalidates your existing stats API clients.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "RolesAllowedToEditJiraSubscriptions",
@@ -6359,7 +6926,9 @@
                 "display_name": "System Admins",
                 "value": "system_admin"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GroupsAllowedToEditJiraSubscriptions",
@@ -6367,9 +6936,12 @@
             "type": "text",
             "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -6417,7 +6989,9 @@
             "type": "bool",
             "help_text": "When false, users cannot attach and create Jira issues in Mattermost. Does not affect Jira webhook notifications. After changing this setting to false, disable, then re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When true, install this plugin to your Jira instance with '/jira install’ to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Secret",
@@ -6426,7 +7000,9 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Jira integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "RolesAllowedToEditJiraSubscriptions",
@@ -6452,7 +7028,9 @@
                 "display_name": "System Admins",
                 "value": "system_admin"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GroupsAllowedToEditJiraSubscriptions",
@@ -6460,9 +7038,12 @@
             "type": "text",
             "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -6510,7 +7091,9 @@
             "type": "bool",
             "help_text": "When false, users cannot attach and create Jira issues in Mattermost. Does not affect Jira webhook notifications. After changing this setting to false, disable, then re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When true, install this plugin to your Jira instance with '/jira install’ to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Secret",
@@ -6519,7 +7102,9 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Jira integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "RolesAllowedToEditJiraSubscriptions",
@@ -6545,7 +7130,9 @@
                 "display_name": "System Admins",
                 "value": "system_admin"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GroupsAllowedToEditJiraSubscriptions",
@@ -6553,9 +7140,12 @@
             "type": "text",
             "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -6603,7 +7193,9 @@
             "type": "bool",
             "help_text": "When false, users cannot attach and create Jira issues in Mattermost. Does not affect Jira webhook notifications. After changing this setting to false, disable, then re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When true, install this plugin to your Jira instance with '/jira install’ to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Secret",
@@ -6612,7 +7204,9 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Jira integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "RolesAllowedToEditJiraSubscriptions",
@@ -6638,7 +7232,9 @@
                 "display_name": "System Admins",
                 "value": "system_admin"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GroupsAllowedToEditJiraSubscriptions",
@@ -6646,9 +7242,12 @@
             "type": "text",
             "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -6696,7 +7295,9 @@
             "type": "bool",
             "help_text": "When false, users cannot attach and create Jira issues in Mattermost. Does not affect Jira webhook notifications. After changing this setting to false, disable, then re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When true, install this plugin to your Jira instance with '/jira install’ to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Secret",
@@ -6705,7 +7306,9 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Jira integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "RolesAllowedToEditJiraSubscriptions",
@@ -6731,7 +7334,9 @@
                 "display_name": "System Admins",
                 "value": "system_admin"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GroupsAllowedToEditJiraSubscriptions",
@@ -6739,9 +7344,12 @@
             "type": "text",
             "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -6789,7 +7397,9 @@
             "type": "bool",
             "help_text": "When false, users cannot attach and create Jira issues in Mattermost. Does not affect Jira webhook notifications. After changing this setting to false, disable, then re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When true, install this plugin to your Jira instance with '/jira install’ to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Secret",
@@ -6798,7 +7408,9 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Jira integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "RolesAllowedToEditJiraSubscriptions",
@@ -6824,7 +7436,9 @@
                 "display_name": "System Admins",
                 "value": "system_admin"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GroupsAllowedToEditJiraSubscriptions",
@@ -6832,9 +7446,12 @@
             "type": "text",
             "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -6882,7 +7499,9 @@
             "type": "bool",
             "help_text": "When false, users cannot attach and create Jira issues in Mattermost. Does not affect Jira webhook notifications. After changing this setting to false, disable, then re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When true, install this plugin to your Jira instance with '/jira install’ to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Secret",
@@ -6891,7 +7510,9 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Jira integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "RolesAllowedToEditJiraSubscriptions",
@@ -6917,7 +7538,9 @@
                 "display_name": "System Admins",
                 "value": "system_admin"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "GroupsAllowedToEditJiraSubscriptions",
@@ -6925,9 +7548,12 @@
             "type": "text",
             "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription.",
             "placeholder": "",
-            "default": ""
+            "default": "",
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -6974,7 +7600,9 @@
             "type": "username",
             "help_text": "Select the username that this integration is attached to.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnableJiraUI",
@@ -6982,7 +7610,9 @@
             "type": "bool",
             "help_text": "When false, users cannot attach and create Jira issues in Mattermost. Does not affect Jira webhook notifications. After changing this setting to false, disable, then re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When true, install this plugin to your Jira instance with '/jira install’ to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Secret",
@@ -6991,9 +7621,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing JIRA integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -7040,7 +7673,9 @@
             "type": "username",
             "help_text": "Select the username that this integration is attached to.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnableJiraUI",
@@ -7048,7 +7683,9 @@
             "type": "bool",
             "help_text": "When false, users cannot attach and create Jira issues in Mattermost. Does not affect Jira webhook notifications. After changing this setting to false, disable, then re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When true, install this plugin to your Jira instance with '/jira install’ to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Secret",
@@ -7057,9 +7694,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing JIRA integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -7103,7 +7743,9 @@
             "type": "bool",
             "help_text": "When true, you can configure JIRA webhooks to post message in Mattermost. To help combat phishing attacks, all posts are labelled by a BOT tag.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "UserName",
@@ -7111,7 +7753,9 @@
             "type": "username",
             "help_text": "Select the username that this integration is attached to.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Secret",
@@ -7120,9 +7764,12 @@
             "help_text": "This secret is used to authenticate to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing JIRA integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -7166,7 +7813,9 @@
             "type": "bool",
             "help_text": "When true, you can configure JIRA webhooks to post message in Mattermost. To help combat phishing attacks, all posts are labelled by a BOT tag.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "UserName",
@@ -7174,7 +7823,9 @@
             "type": "username",
             "help_text": "Select the username that this integration is attached to.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Secret",
@@ -7183,9 +7834,12 @@
             "help_text": "This secret is used to authenticate to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing JIRA integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -7229,7 +7883,9 @@
             "type": "bool",
             "help_text": "When true, you can configure JIRA webhooks to post message in Mattermost. To help combat phishing attacks, all posts are labelled by a BOT tag.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "UserName",
@@ -7237,7 +7893,9 @@
             "type": "username",
             "help_text": "Select the username that this integration is attached to.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Secret",
@@ -7246,9 +7904,12 @@
             "help_text": "This secret is used to authenticate to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing JIRA integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -7292,7 +7953,9 @@
             "type": "bool",
             "help_text": "When true, you can configure JIRA webhooks to post message in Mattermost. To help combat phishing attacks, all posts are labelled by a BOT tag.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "UserName",
@@ -7300,7 +7963,9 @@
             "type": "username",
             "help_text": "Select the username that this integration is attached to.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Secret",
@@ -7309,9 +7974,12 @@
             "help_text": "This secret is used to authenticate to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing JIRA integrations.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -7363,7 +8031,9 @@
             "type": "text",
             "help_text": "The URL for your Jitsi server, for example https://jitsi.example.com. Defaults to https://meet.jit.si, which is the public server provided by Jitsi.",
             "placeholder": "https://meet.jit.si",
-            "default": "https://meet.jit.si"
+            "default": "https://meet.jit.si",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "JitsiEmbedded",
@@ -7371,7 +8041,9 @@
             "type": "bool",
             "help_text": "(Experimental) When true, Jitsi video is embedded as a floating window inside Mattermost by default. Users can override this setting with '/jitsi settings'",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "JitsiNamingScheme",
@@ -7397,7 +8069,9 @@
                 "display_name": "Allow user to select meeting name",
                 "value": "ask"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "JitsiJWT",
@@ -7405,7 +8079,9 @@
             "type": "bool",
             "help_text": "(Optional) If your Jitsi server uses JSON Web Tokens (JWT) for authentication, set this value to true.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "JitsiAppID",
@@ -7413,7 +8089,9 @@
             "type": "text",
             "help_text": "(Optional) The App ID used for authentication by the Jitsi server and JWT token generator.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "JitsiAppSecret",
@@ -7421,7 +8099,9 @@
             "type": "text",
             "help_text": "(Optional) The App Secret used for authentication by the Jitsi server and JWT token generator.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "JitsiLinkValidTime",
@@ -7429,7 +8109,9 @@
             "type": "number",
             "help_text": "(Optional) The number of minutes from when the meeting link is created to when it becomes invalid. Minimum is 1 minute. Only applies if using JWT authentication for your Jitsi server.",
             "placeholder": "",
-            "default": 30
+            "default": 30,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "JitsiCompatibilityMode",
@@ -7437,9 +8119,12 @@
             "type": "bool",
             "help_text": "(Insecure) If your Jitsi server is not compatible with this plugin, include the JavaScript API hosted on your Jitsi server directly in Mattermost instead of the default API version provided by the plugin. **WARNING:** Enabling this setting can compromise the security of your Mattermost system, if your Jitsi server is not fully trusted and allows direct modification of program files. Use with caution.",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -7495,7 +8180,9 @@
             "type": "bool",
             "help_text": "",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnableOnUpdate",
@@ -7503,7 +8190,9 @@
             "type": "bool",
             "help_text": "",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "PluginAdmins",
@@ -7511,9 +8200,12 @@
             "type": "text",
             "help_text": "Comma-separated list of userIDs authorized to administer the plugin in addition to the System Admins.\n \nUser IDs can be found by navigating to **System Console** > **Users**.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -7569,7 +8261,9 @@
             "type": "bool",
             "help_text": "",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnableOnUpdate",
@@ -7577,7 +8271,9 @@
             "type": "bool",
             "help_text": "",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "PluginAdmins",
@@ -7585,9 +8281,12 @@
             "type": "text",
             "help_text": "Comma-separated list of userIDs authorized to administer the plugin in addition to the System Admins.\n \nUser IDs can be found by navigating to **System Console** > **Users**.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -7641,9 +8340,12 @@
             "type": "bool",
             "help_text": "",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -7697,9 +8399,12 @@
             "type": "bool",
             "help_text": "",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -7743,9 +8448,12 @@
             "type": "bool",
             "help_text": "",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -7782,7 +8490,8 @@
       "settings_schema": {
         "header": "Configure this plugin directly in the config.json file. Learn more [in our documentation](https://github.com/mattermost/mattermost-plugin-autolink/blob/master/README.md).\n\nTo report an issue, make a suggestion or a contribution, [check the plugin repository](https://github.com/mattermost/mattermost-plugin-autolink).",
         "footer": "",
-        "settings": null
+        "settings": null,
+        "sections": null
       }
     },
     "platforms": {
@@ -7819,7 +8528,8 @@
       "settings_schema": {
         "header": "Configure this plugin directly in the config.json file. Learn more [in our documentation](https://github.com/mattermost/mattermost-plugin-autolink/blob/master/README.md).\n\nTo report an issue, make a suggestion or a contribution, [check the plugin repository](https://github.com/mattermost/mattermost-plugin-autolink).",
         "footer": "",
-        "settings": null
+        "settings": null,
+        "sections": null
       }
     },
     "platforms": {
@@ -7867,7 +8577,9 @@
             "type": "bool",
             "help_text": "If set the plugin will reject posts containing profanity instead of censoring.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WarningMessage",
@@ -7875,7 +8587,9 @@
             "type": "text",
             "help_text": "If Reject Posts is enabled, this message will be sent to the user to warn him. Place `%s` where you want to cite the forbidden word in the message. Markdown formatted.",
             "placeholder": "Ex. Your post has been rejected by the Profanity Filter, because the following word is not allowed: `%s`.",
-            "default": "Your post has been rejected by the Profanity Filter, because the following word is not allowed: `%s`."
+            "default": "Your post has been rejected by the Profanity Filter, because the following word is not allowed: `%s`.",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "CensorCharacter",
@@ -7883,7 +8597,9 @@
             "type": "text",
             "help_text": "The character(s) to use to censor profanity. Censored words' letters will be replaced with this character. Note that markdown will be interpreted. You can escape markdown character with a backslash. For using `*` you type `\\*`.",
             "placeholder": "Ex. \\*",
-            "default": "\\*"
+            "default": "\\*",
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "BadWordsList",
@@ -7891,9 +8607,12 @@
             "type": "longtext",
             "help_text": "The words to censor, separated by commas. Accentuation and punctuation insensitive. [Regular expressions](https://en.wikipedia.org/wiki/Regular_expression) are interpreted: if you want to censor characters as `.`, `?`, `*`, `{`, `}`, `[`, `]`, please double-escape them like `\\\\.`",
             "placeholder": "",
-            "default": "4r5e,5h1t,5hit,a55,anal,anus,ar5e,arrse,arse,ass(es)?,ass[-]?fucker,assfukka,assholes?,asswhole,a_s_s,b!tch,b17ch,b1tch,ballbag,ballsack,bastard,beastial,beastiality,bellend,bestial,bestiality,bi+ch,biatch,bitch,bitcher,bitchers,bitches,bitchin,bitching,bloody,blow[ ]?jobs?,boiolas,bollock,bollok,boner,b[o0][o0]+bs?,breasts,buceta,bugger,bum,bunny fucker,butt,butt[ ]?hole,buttmuch,buttplug,c[0o]cks?,c0cksucker,carpet muncher,cawk,chink,cipa,cl[i1]t,clitoris,clits,cnut,cock-sucker,cockface,cockhead,cockmunch,cockmuncher,cocksucks?,cocksucked,cocksucker,cocksucking,cocksuka,cocksukka,cok,cokmuncher,coksucka,coon,cox,crap,cums?,cummer,cumming,cumshot?,cunilingus,cunillingus,cunnilingus,cunt,cuntlick,cuntlicker,cuntlicking,cunts,cyalis,cyberfuc,cyberfuck,cyberfucked,cyberfucker,cyberfuckers,cyberfucking,d1ck,damn,dick,dickhead,dildo,dildos,dink,dinks,dirsa,dlck,dog-fucker,doggin,dogging,donkeyribber,doosh,duche,dyke,ejaculate,ejaculated,ejaculates,ejaculating,ejaculatings,ejaculation,ejakulate,f[[:space:]]*u[[:space:]]*c[[:space:]]*k,f[[:space:]]*u[[:space:]]*c[[:space:]]*k[[:space:]]*e[[:space:]]*r,f4nny,fag,fagging,faggitt,faggot,faggs,fagot,fagots,fags,fanny,fannyflaps,fannyfucker,fanyy,fatass,fcuk,fcuker,fcuking,feck,fecker,felching,fellate,fellatio,fingerfuck,fingerfucked,fingerfucker,fingerfuckers,fingerfucking,fingerfucks,fistfuck,fistfucked,fistfucker,fistfuckers,fistfucking,fistfuckings,fistfucks,flange,fook,fooker,fuck,fucka,fucked,fucker,fuckers,fuckhead,fuckheads,fuckin,fucking,fuckings,fuckingshitmother[[:space:]]*fucker,fuckme,fucks,fuckwhit,fuckwit,fudge packer,fudgepacker,fuk,fuker,fukker,fukkin,fuks,fukwhit,fukwit,fux,fux0r,f_u_c_k,gangbang,gangbanged,gangbangs,gaylord,gaysex,goatse,God,god-dam,god-damned,goddamn,goddamned,hardcoresex,hell,heshe,hoar,hoare,hoer,homo,hore,horniest,horny,hotsex,jack-off,jackoff,jap,jerk-off,jism,jiz,jizm,jizz,kawk,knob,knobead,knobed,knobend,knobhead,knobjocky,knobjokey,kock,kondum,kondums,kum,kummer,kumming,kums,kunilingus,l3i\\+ch,l3itch,labia,lust,lusting,m0f0,m0fo,m[a4][s5]terb(at[3e]|8),ma5terbate,masochist,master-bate,masterbations?,mo-fo,mof[o0],motha[[:space:]]*fuck,motha[[:space:]]*fuckas?,motha[[:space:]]*fuckaz,motha[[:space:]]*fucked,motha[[:space:]]*fuckers?,motha[[:space:]]*fuckin,motha[[:space:]]*fucking,motha[[:space:]]*fuckings,motha[[:space:]]*fucks,mother[[:space:]]*fuck,mother[[:space:]]*fucked,mother fucker,mother fuckers,mother fuckin,mother fucking,mother fuckings,mother fuckka,mother fucks,mother[[:space:]]*fucker,mother[[:space:]]*fuckers,mother[[:space:]]*fuckin,mother[[:space:]]*fucking,mother[[:space:]]*fuckings,mother[[:space:]]*fuckka,mother[[:space:]]*fucks,muff,mutha,muthafecker,muthafuckker,muther,mutherfucker,n[i1]gg[ea3]r?s?,niggaz,nob,nob jokey,nobhead,nobjocky,nobjokey,numbnuts,nutsack,orgasims?,orgasms?,p[o0]rno?s?,pawn,pecker,penis,penisfucker,phonesex,phuck,phuk,phuked,phuking,phukked,phukking,phuks,phuq,pigfucker,pimpis,piss,pissed,pisser,pissers,pisses,pissflaps,pissin,pissing,pissoff,poop,pornography,prick,pricks,pron,pube,pusse,puss[iy]e?s?,rectum,retard,rimjaw,rimming,s[[:space:]]*h[[:space:]]*i[[:space:]]*t,s\\.o\\.b\\.,sadist,schlong,screwing,scroat,scrote,scrotum,semen,sex,shag,shagger,shaggin,shagging,shemale,sh[i1!][t+]s?,shitdick,shite,shited,shitey,shitfuck,shitfull,shithead,shiting,shitings,shitted,shitter,shitters,shitting,shittings,shitty,skank,sluts?,smegma,smut,snatch,son-of-a-bitch,spac,spunk,t1tt1e5,t1tties,teets,teez,testical,testicle,tits?,titfuck,titt,tittie5,tittiefucker,titties?,tittyfuck,tittywank,titwank,tosser,turd,tw[4a]t,twathead,twatty,twunt,twunter,v14gra,v1gra,vagina,viagra,vulva,w00se,wang,wank,wanker,wanky,whoar,whores?,willies,willy,xrated,x[[:space:]]*x[[:space:]]*x"
+            "default": "4r5e,5h1t,5hit,a55,anal,anus,ar5e,arrse,arse,ass(es)?,ass[-]?fucker,assfukka,assholes?,asswhole,a_s_s,b!tch,b17ch,b1tch,ballbag,ballsack,bastard,beastial,beastiality,bellend,bestial,bestiality,bi+ch,biatch,bitch,bitcher,bitchers,bitches,bitchin,bitching,bloody,blow[ ]?jobs?,boiolas,bollock,bollok,boner,b[o0][o0]+bs?,breasts,buceta,bugger,bum,bunny fucker,butt,butt[ ]?hole,buttmuch,buttplug,c[0o]cks?,c0cksucker,carpet muncher,cawk,chink,cipa,cl[i1]t,clitoris,clits,cnut,cock-sucker,cockface,cockhead,cockmunch,cockmuncher,cocksucks?,cocksucked,cocksucker,cocksucking,cocksuka,cocksukka,cok,cokmuncher,coksucka,coon,cox,crap,cums?,cummer,cumming,cumshot?,cunilingus,cunillingus,cunnilingus,cunt,cuntlick,cuntlicker,cuntlicking,cunts,cyalis,cyberfuc,cyberfuck,cyberfucked,cyberfucker,cyberfuckers,cyberfucking,d1ck,damn,dick,dickhead,dildo,dildos,dink,dinks,dirsa,dlck,dog-fucker,doggin,dogging,donkeyribber,doosh,duche,dyke,ejaculate,ejaculated,ejaculates,ejaculating,ejaculatings,ejaculation,ejakulate,f[[:space:]]*u[[:space:]]*c[[:space:]]*k,f[[:space:]]*u[[:space:]]*c[[:space:]]*k[[:space:]]*e[[:space:]]*r,f4nny,fag,fagging,faggitt,faggot,faggs,fagot,fagots,fags,fanny,fannyflaps,fannyfucker,fanyy,fatass,fcuk,fcuker,fcuking,feck,fecker,felching,fellate,fellatio,fingerfuck,fingerfucked,fingerfucker,fingerfuckers,fingerfucking,fingerfucks,fistfuck,fistfucked,fistfucker,fistfuckers,fistfucking,fistfuckings,fistfucks,flange,fook,fooker,fuck,fucka,fucked,fucker,fuckers,fuckhead,fuckheads,fuckin,fucking,fuckings,fuckingshitmother[[:space:]]*fucker,fuckme,fucks,fuckwhit,fuckwit,fudge packer,fudgepacker,fuk,fuker,fukker,fukkin,fuks,fukwhit,fukwit,fux,fux0r,f_u_c_k,gangbang,gangbanged,gangbangs,gaylord,gaysex,goatse,God,god-dam,god-damned,goddamn,goddamned,hardcoresex,hell,heshe,hoar,hoare,hoer,homo,hore,horniest,horny,hotsex,jack-off,jackoff,jap,jerk-off,jism,jiz,jizm,jizz,kawk,knob,knobead,knobed,knobend,knobhead,knobjocky,knobjokey,kock,kondum,kondums,kum,kummer,kumming,kums,kunilingus,l3i\\+ch,l3itch,labia,lust,lusting,m0f0,m0fo,m[a4][s5]terb(at[3e]|8),ma5terbate,masochist,master-bate,masterbations?,mo-fo,mof[o0],motha[[:space:]]*fuck,motha[[:space:]]*fuckas?,motha[[:space:]]*fuckaz,motha[[:space:]]*fucked,motha[[:space:]]*fuckers?,motha[[:space:]]*fuckin,motha[[:space:]]*fucking,motha[[:space:]]*fuckings,motha[[:space:]]*fucks,mother[[:space:]]*fuck,mother[[:space:]]*fucked,mother fucker,mother fuckers,mother fuckin,mother fucking,mother fuckings,mother fuckka,mother fucks,mother[[:space:]]*fucker,mother[[:space:]]*fuckers,mother[[:space:]]*fuckin,mother[[:space:]]*fucking,mother[[:space:]]*fuckings,mother[[:space:]]*fuckka,mother[[:space:]]*fucks,muff,mutha,muthafecker,muthafuckker,muther,mutherfucker,n[i1]gg[ea3]r?s?,niggaz,nob,nob jokey,nobhead,nobjocky,nobjokey,numbnuts,nutsack,orgasims?,orgasms?,p[o0]rno?s?,pawn,pecker,penis,penisfucker,phonesex,phuck,phuk,phuked,phuking,phukked,phukking,phuks,phuq,pigfucker,pimpis,piss,pissed,pisser,pissers,pisses,pissflaps,pissin,pissing,pissoff,poop,pornography,prick,pricks,pron,pube,pusse,puss[iy]e?s?,rectum,retard,rimjaw,rimming,s[[:space:]]*h[[:space:]]*i[[:space:]]*t,s\\.o\\.b\\.,sadist,schlong,screwing,scroat,scrote,scrotum,semen,sex,shag,shagger,shaggin,shagging,shemale,sh[i1!][t+]s?,shitdick,shite,shited,shitey,shitfuck,shitfull,shithead,shiting,shitings,shitted,shitter,shitters,shitting,shittings,shitty,skank,sluts?,smegma,smut,snatch,son-of-a-bitch,spac,spunk,t1tt1e5,t1tties,teets,teez,testical,testicle,tits?,titfuck,titt,tittie5,tittiefucker,titties?,tittyfuck,tittywank,titwank,tosser,turd,tw[4a]t,twathead,twatty,twunt,twunter,v14gra,v1gra,vagina,viagra,vulva,w00se,wang,wank,wanker,wanky,whoar,whores?,willies,willy,xrated,x[[:space:]]*x[[:space:]]*x",
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -7943,7 +8662,8 @@
       "settings_schema": {
         "header": "",
         "footer": "* To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/mattermost/mattermost-plugin-memes).",
-        "settings": null
+        "settings": null,
+        "sections": null
       }
     },
     "platforms": {
@@ -7993,7 +8713,8 @@
       "settings_schema": {
         "header": "",
         "footer": "* To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/mattermost/mattermost-plugin-memes).",
-        "settings": null
+        "settings": null,
+        "sections": null
       }
     },
     "platforms": {
@@ -8063,7 +8784,9 @@
                 "display_name": "Online",
                 "value": "online"
               }
-            ]
+            ],
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Username",
@@ -8071,7 +8794,9 @@
             "type": "text",
             "help_text": "Username of your selected bot account. We strongly recommend using a dedicated bot account for this plugin, rather than an existing Skype for Business user account. Only required for Skype for Business Server.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Password",
@@ -8079,7 +8804,9 @@
             "type": "text",
             "help_text": "Password of your selected bot account. Only required for Skype for Business Server.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "Domain",
@@ -8087,7 +8814,9 @@
             "type": "text",
             "help_text": "The domain of your Skype for Business server instance. For example, contoso.com. Only required for Skype for Business Server.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ClientId",
@@ -8095,9 +8824,12 @@
             "type": "text",
             "help_text": "Application ID from the Azure Active Directory. Only required for Skype for Business Online. Use this URL to configure the plugin in Azure Active Directory: ```https://SITEURL/plugins/skype4business/api/v1/auth_redirect```",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -8158,7 +8890,9 @@
             "type": "text",
             "help_text": "The URL for a self-hosted private cloud or on-premise Zoom server. For example, https://yourzoom.com. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://zoom.us",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ZoomAPIURL",
@@ -8166,7 +8900,9 @@
             "type": "text",
             "help_text": "The API URL for a self-hosted private cloud or on-premise Zoom server. For example, https://api.yourzoom.com/v2. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://api.zoom.us/v2",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnableOAuth",
@@ -8174,7 +8910,9 @@
             "type": "bool",
             "help_text": "When true, OAuth will be used as the authentication means with Zoom. \n When false, JWT will be used as the authentication means with Zoom. \n If you are currently using a JWT Zoom application and switch to OAuth, all users will need to connect their Zoom account using OAuth the next time they try to start a meeting. [More information](https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration).",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "AccountLevelApp",
@@ -8182,7 +8920,9 @@
             "type": "bool",
             "help_text": "When true, only an account administrator has to log in. The rest of the users will use their e-mail to log in.",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "OAuthClientID",
@@ -8190,7 +8930,9 @@
             "type": "text",
             "help_text": "The Client ID for the OAuth app registered with Zoom. Leave blank if not using OAuth",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "OAuthClientSecret",
@@ -8198,7 +8940,9 @@
             "type": "text",
             "help_text": "The Client Secret for the OAuth app registered with Zoom. Leave blank if not using OAuth",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -8207,7 +8951,9 @@
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "regenerate_help_text": "Regenerates the encryption key for Zoom OAuth Token. Regenerating the key invalidates your existing Zoom OAuth.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APIKey",
@@ -8215,7 +8961,9 @@
             "type": "text",
             "help_text": "The API Key generated by Zoom, used to create meetings and pull user data.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APISecret",
@@ -8223,7 +8971,9 @@
             "type": "text",
             "help_text": "The API Secret generated by Zoom for your API key.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -8232,9 +8982,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Zoom plugin.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -8295,7 +9048,9 @@
             "type": "text",
             "help_text": "The URL for a self-hosted private cloud or on-premise Zoom server. For example, https://yourzoom.com. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://zoom.us",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ZoomAPIURL",
@@ -8303,7 +9058,9 @@
             "type": "text",
             "help_text": "The API URL for a self-hosted private cloud or on-premise Zoom server. For example, https://api.yourzoom.com/v2. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://api.zoom.us/v2",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "AccountLevelApp",
@@ -8311,7 +9068,9 @@
             "type": "bool",
             "help_text": "When true, only an account administrator has to log in. The rest of the users will use their e-mail to log in.",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "OAuthClientID",
@@ -8319,7 +9078,9 @@
             "type": "text",
             "help_text": "The Client ID for the OAuth app registered with Zoom. Leave blank if not using OAuth",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "OAuthClientSecret",
@@ -8327,7 +9088,9 @@
             "type": "text",
             "help_text": "The Client Secret for the OAuth app registered with Zoom. Leave blank if not using OAuth",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -8336,7 +9099,9 @@
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "regenerate_help_text": "Regenerates the encryption key for Zoom OAuth Token. Regenerating the key invalidates your existing Zoom OAuth.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -8345,9 +9110,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Zoom plugin.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -8407,7 +9175,9 @@
             "type": "text",
             "help_text": "The URL for a self-hosted private cloud or on-premise Zoom server. For example, https://yourzoom.com. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://zoom.us",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ZoomAPIURL",
@@ -8415,7 +9185,9 @@
             "type": "text",
             "help_text": "The API URL for a self-hosted private cloud or on-premise Zoom server. For example, https://api.yourzoom.com/v2. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://api.zoom.us/v2",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnableOAuth",
@@ -8423,7 +9195,9 @@
             "type": "bool",
             "help_text": "When true, OAuth will be used as the authentication means with Zoom. \n When false, JWT will be used as the authentication means with Zoom. \n If you are currently using a JWT Zoom application and switch to OAuth, all users will need to connect their Zoom account using OAuth the next time they try to start a meeting. [More information](https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration).",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "OAuthClientID",
@@ -8431,7 +9205,9 @@
             "type": "text",
             "help_text": "The Client ID for the OAuth app registered with Zoom. Leave blank if not using OAuth",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "OAuthClientSecret",
@@ -8439,7 +9215,9 @@
             "type": "text",
             "help_text": "The Client Secret for the OAuth app registered with Zoom. Leave blank if not using OAuth",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -8448,7 +9226,9 @@
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "regenerate_help_text": "Regenerates the encryption key for Zoom OAuth Token. Regenerating the key invalidates your existing Zoom OAuth.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APIKey",
@@ -8456,7 +9236,9 @@
             "type": "text",
             "help_text": "The API Key generated by Zoom, used to create meetings and pull user data.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APISecret",
@@ -8464,7 +9246,9 @@
             "type": "text",
             "help_text": "The API Secret generated by Zoom for your API key.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -8473,9 +9257,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Zoom plugin.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -8535,7 +9322,9 @@
             "type": "text",
             "help_text": "The URL for a self-hosted private cloud or on-premise Zoom server. For example, https://yourzoom.com. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://zoom.us",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ZoomAPIURL",
@@ -8543,7 +9332,9 @@
             "type": "text",
             "help_text": "The API URL for a self-hosted private cloud or on-premise Zoom server. For example, https://api.yourzoom.com/v2. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://api.zoom.us/v2",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnableOAuth",
@@ -8551,7 +9342,9 @@
             "type": "bool",
             "help_text": "When true, OAuth will be used as the authentication means with Zoom. \n Only Enable OAuth OR Password based authentication. Not both. If you are currently using a JWT Zoom application and switch to OAuth, all users will need to connect their Zoom account using OAuth the next time they try to start a meeting. [More information](https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration).",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "OAuthClientID",
@@ -8559,7 +9352,9 @@
             "type": "text",
             "help_text": "The Client ID for the OAuth app registered with Zoom. Leave blank if not using OAuth",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "OAuthClientSecret",
@@ -8567,7 +9362,9 @@
             "type": "text",
             "help_text": "The Client Secret for the OAuth app registered with Zoom. Leave blank if not using OAuth",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -8576,7 +9373,9 @@
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "regenerate_help_text": "Regenerates the encryption key for Zoom OAuth Token. Regenerating the key invalidates your existing Zoom OAuth.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnableLegacyAuth",
@@ -8584,7 +9383,9 @@
             "type": "bool",
             "help_text": "When true, user's email and password will be used to authenticate with Zoom. \n Only Enable OAuth OR Password based authentication. Not both. [More information](https://mattermost.gitbook.io/plugin-zoom/installation/zoom-configuration).",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APIKey",
@@ -8592,7 +9393,9 @@
             "type": "text",
             "help_text": "The API Key generated by Zoom, used to create meetings and pull user data.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APISecret",
@@ -8600,7 +9403,9 @@
             "type": "text",
             "help_text": "The API Secret generated by Zoom for your API key.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -8609,9 +9414,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Zoom plugin.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -8671,7 +9479,9 @@
             "type": "text",
             "help_text": "The URL for a self-hosted private cloud or on-premise Zoom server. For example, https://yourzoom.com. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://zoom.us",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ZoomAPIURL",
@@ -8679,7 +9489,9 @@
             "type": "text",
             "help_text": "The API URL for a self-hosted private cloud or on-premise Zoom server. For example, https://api.yourzoom.com/v2. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://api.zoom.us/v2",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APIKey",
@@ -8687,7 +9499,9 @@
             "type": "text",
             "help_text": "The API Key generated by Zoom, used to create meetings and pull user data.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APISecret",
@@ -8695,7 +9509,9 @@
             "type": "text",
             "help_text": "The API Secret generated by Zoom for your API key.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -8704,9 +9520,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Zoom plugin.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -8765,7 +9584,9 @@
             "type": "text",
             "help_text": "The URL for a self-hosted private cloud or on-premise Zoom server. For example, https://yourzoom.com. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://zoom.us",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ZoomAPIURL",
@@ -8773,7 +9594,9 @@
             "type": "text",
             "help_text": "The API URL for a self-hosted private cloud or on-premise Zoom server. For example, https://api.yourzoom.com/v2. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://api.zoom.us/v2",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APIKey",
@@ -8781,7 +9604,9 @@
             "type": "text",
             "help_text": "The API Key generated by Zoom, used to create meetings and pull user data.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APISecret",
@@ -8789,7 +9614,9 @@
             "type": "text",
             "help_text": "The API Secret generated by Zoom for your API key.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -8798,9 +9625,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Zoom plugin.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -8857,7 +9687,9 @@
             "type": "text",
             "help_text": "The URL for a self-hosted private cloud or on-premise Zoom server. For example, https://yourzoom.com. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://zoom.us",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ZoomAPIURL",
@@ -8865,7 +9697,9 @@
             "type": "text",
             "help_text": "The API URL for a self-hosted private cloud or on-premise Zoom server. For example, https://api.yourzoom.com/v2. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://api.zoom.us/v2",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnableOAuth",
@@ -8873,7 +9707,9 @@
             "type": "bool",
             "help_text": "When true, OAuth will be used as authentication means with Zoom. \n Please enable only either one of OAuth based or Password base authentication.",
             "placeholder": "",
-            "default": false
+            "default": false,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "OAuthClientID",
@@ -8881,7 +9717,9 @@
             "type": "text",
             "help_text": "The Client ID for the OAuth app registered with Zoom. Leave blank if not using OAuth",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "OAuthClientSecret",
@@ -8889,7 +9727,9 @@
             "type": "text",
             "help_text": "The Client Secret for the OAuth app registered with Zoom. Leave blank if not using OAuth",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EncryptionKey",
@@ -8898,7 +9738,9 @@
             "help_text": "The AES encryption key used to encrypt stored access tokens.",
             "regenerate_help_text": "Regenerates the encryption key for Zoom OAuth Token. Regenerating the key invalidates your existing Zoom OAuth.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "EnableLegacyAuth",
@@ -8906,7 +9748,9 @@
             "type": "bool",
             "help_text": "When true, user's email and password will be used to authenticate with Zoom. \n Please enable only either one of OAuth based or Password base authentication.",
             "placeholder": "",
-            "default": true
+            "default": true,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APIKey",
@@ -8914,7 +9758,9 @@
             "type": "text",
             "help_text": "The API Key generated by Zoom, used to create meetings and pull user data.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APISecret",
@@ -8922,7 +9768,9 @@
             "type": "text",
             "help_text": "The API Secret generated by Zoom for your API key.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -8931,9 +9779,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Zoom plugin.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -8990,7 +9841,9 @@
             "type": "text",
             "help_text": "The URL for a self-hosted private cloud or on-premise Zoom server. For example, https://yourzoom.com. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://zoom.us",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ZoomAPIURL",
@@ -8998,7 +9851,9 @@
             "type": "text",
             "help_text": "The API URL for a self-hosted private cloud or on-premise Zoom server. For example, https://api.yourzoom.com/v2. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://api.zoom.us/v2",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APIKey",
@@ -9006,7 +9861,9 @@
             "type": "text",
             "help_text": "The API Key generated by Zoom, used to create meetings and pull user data.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APISecret",
@@ -9014,7 +9871,9 @@
             "type": "text",
             "help_text": "The API Secret generated by Zoom for your API key.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -9023,9 +9882,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Zoom plugin.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -9073,7 +9935,9 @@
             "type": "text",
             "help_text": "The URL for a self-hosted private cloud or on-premise Zoom server. For example, https://yourzoom.com. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://zoom.us",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ZoomAPIURL",
@@ -9081,7 +9945,9 @@
             "type": "text",
             "help_text": "The API URL for a self-hosted private cloud or on-premise Zoom server. For example, https://api.yourzoom.com/v2. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://api.zoom.us/v2",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APIKey",
@@ -9089,7 +9955,9 @@
             "type": "text",
             "help_text": "The API Key generated by Zoom, used to create meetings and pull user data.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APISecret",
@@ -9097,7 +9965,9 @@
             "type": "text",
             "help_text": "The API Secret generated by Zoom for your API key.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -9106,9 +9976,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Zoom plugin.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -9156,7 +10029,9 @@
             "type": "text",
             "help_text": "The URL for a self-hosted private cloud or on-premise Zoom server. For example, https://yourzoom.com. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://zoom.us",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ZoomAPIURL",
@@ -9164,7 +10039,9 @@
             "type": "text",
             "help_text": "The API URL for a self-hosted private cloud or on-premise Zoom server. For example, https://api.yourzoom.com/v2. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://api.zoom.us/v2",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APIKey",
@@ -9172,7 +10049,9 @@
             "type": "text",
             "help_text": "The API Key generated by Zoom, used to create meetings and pull user data.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APISecret",
@@ -9180,7 +10059,9 @@
             "type": "text",
             "help_text": "The API Secret generated by Zoom for your API key.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -9189,9 +10070,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Zoom plugin.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -9238,7 +10122,9 @@
             "type": "text",
             "help_text": "The URL for a self-hosted private cloud or on-premise Zoom server. For example, https://yourzoom.com. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://zoom.us",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ZoomAPIURL",
@@ -9246,7 +10132,9 @@
             "type": "text",
             "help_text": "The API URL for a self-hosted private cloud or on-premise Zoom server. For example, https://api.yourzoom.com/v2. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://api.zoom.us/v2",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APIKey",
@@ -9254,7 +10142,9 @@
             "type": "text",
             "help_text": "The API Key generated by Zoom, used to create meetings and pull user data.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APISecret",
@@ -9262,7 +10152,9 @@
             "type": "text",
             "help_text": "The API Secret generated by Zoom for your API key.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -9271,9 +10163,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Zoom plugin.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -9320,7 +10215,9 @@
             "type": "text",
             "help_text": "The URL for a self-hosted private cloud or on-premise Zoom server. For example, https://yourzoom.com. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://zoom.us",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ZoomAPIURL",
@@ -9328,7 +10225,9 @@
             "type": "text",
             "help_text": "The API URL for a self-hosted private cloud or on-premise Zoom server. For example, https://api.yourzoom.com/v2. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://api.zoom.us/v2",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APIKey",
@@ -9336,7 +10235,9 @@
             "type": "text",
             "help_text": "The API Key generated by Zoom, used to create meetings and pull user data.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APISecret",
@@ -9344,7 +10245,9 @@
             "type": "text",
             "help_text": "The API Secret generated by Zoom for your API key.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -9353,9 +10256,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Zoom plugin.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -9402,7 +10308,9 @@
             "type": "text",
             "help_text": "The URL for a self-hosted private cloud or on-premise Zoom server. For example, https://yourzoom.com. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://zoom.us",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ZoomAPIURL",
@@ -9410,7 +10318,9 @@
             "type": "text",
             "help_text": "The API URL for a self-hosted private cloud or on-premise Zoom server. For example, https://api.yourzoom.com/v2. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://api.zoom.us/v2",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APIKey",
@@ -9418,7 +10328,9 @@
             "type": "text",
             "help_text": "The API Key generated by Zoom, used to create meetings and pull user data.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APISecret",
@@ -9426,7 +10338,9 @@
             "type": "text",
             "help_text": "The API Secret generated by Zoom for your API key.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -9435,9 +10349,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Zoom plugin.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -9484,7 +10401,9 @@
             "type": "text",
             "help_text": "The URL for a self-hosted private cloud or on-premise Zoom server. For example, https://yourzoom.com. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://zoom.us",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ZoomAPIURL",
@@ -9492,7 +10411,9 @@
             "type": "text",
             "help_text": "The API URL for a self-hosted private cloud or on-premise Zoom server. For example, https://api.yourzoom.com/v2. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://api.zoom.us/v2",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APIKey",
@@ -9500,7 +10421,9 @@
             "type": "text",
             "help_text": "The API Key generated by Zoom, used to create meetings and pull user data.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APISecret",
@@ -9508,7 +10431,9 @@
             "type": "text",
             "help_text": "The API Secret generated by Zoom for your API key.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -9517,9 +10442,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Zoom plugin.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -9566,7 +10494,9 @@
             "type": "text",
             "help_text": "The URL for a self-hosted private cloud or on-premise Zoom server. For example, https://yourzoom.com. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://zoom.us",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ZoomAPIURL",
@@ -9574,7 +10504,9 @@
             "type": "text",
             "help_text": "The API URL for a self-hosted private cloud or on-premise Zoom server. For example, https://api.yourzoom.com/v2. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://api.zoom.us/v2",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APIKey",
@@ -9582,7 +10514,9 @@
             "type": "text",
             "help_text": "The API Key generated by Zoom, used to create meetings and pull user data.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APISecret",
@@ -9590,7 +10524,9 @@
             "type": "text",
             "help_text": "The API Secret generated by Zoom for your API key.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -9599,9 +10535,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Zoom plugin.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {
@@ -9648,7 +10587,9 @@
             "type": "text",
             "help_text": "The URL for a self-hosted private cloud or on-premise Zoom server. For example, https://yourzoom.com. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://zoom.us",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "ZoomAPIURL",
@@ -9656,7 +10597,9 @@
             "type": "text",
             "help_text": "The API URL for a self-hosted private cloud or on-premise Zoom server. For example, https://api.yourzoom.com/v2. Leave blank if you're using Zoom's vendor-hosted SaaS service.",
             "placeholder": "https://api.zoom.us/v2",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APIKey",
@@ -9664,7 +10607,9 @@
             "type": "text",
             "help_text": "The API Key generated by Zoom, used to create meetings and pull user data.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "APISecret",
@@ -9672,7 +10617,9 @@
             "type": "text",
             "help_text": "The API Secret generated by Zoom for your API key.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           },
           {
             "key": "WebhookSecret",
@@ -9681,9 +10628,12 @@
             "help_text": "The secret used to authenticate the webhook to Mattermost.",
             "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Zoom plugin.",
             "placeholder": "",
-            "default": null
+            "default": null,
+            "hosting": "",
+            "secret": false
           }
-        ]
+        ],
+        "sections": null
       }
     },
     "platforms": {


### PR DESCRIPTION
#### Summary
This PR upgrades the [channel export plugin](https://github.com/mattermost/mattermost-plugin-channel-export) to version [1.2.1](https://github.com/mattermost/mattermost-plugin-channel-export/releases/tag/v1.2.1).  

Note, the generator tool has added defaults to all plugin definitions for the new fields added by a different PR.  


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60340
https://mattermost.atlassian.net/browse/MM-60277
