### PR TITLE
Add v2.4.0 of mattermost-plugin-github to the marketplace

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -27910,6 +27910,215 @@
   {
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-github",
     "icon_data": "data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+R2l0SHViIGljb248L3RpdGxlPjxwYXRoIGQ9Ik0xMiAuMjk3Yy02LjYzIDAtMTIgNS4zNzMtMTIgMTIgMCA1LjMwMyAzLjQzOCA5LjggOC4yMDUgMTEuMzg1LjYuMTEzLjgyLS4yNTguODItLjU3NyAwLS4yODUtLjAxLTEuMDQtLjAxNS0yLjA0LTMuMzM4LjcyNC00LjA0Mi0xLjYxLTQuMDQyLTEuNjFDNC40MjIgMTguMDcgMy42MzMgMTcuNyAzLjYzMyAxNy43Yy0xLjA4Ny0uNzQ0LjA4NC0uNzI5LjA4NC0uNzI5IDEuMjA1LjA4NCAxLjgzOCAxLjIzNiAxLjgzOCAxLjIzNiAxLjA3IDEuODM1IDIuODA5IDEuMzA1IDMuNDk1Ljk5OC4xMDgtLjc3Ni40MTctMS4zMDUuNzYtMS42MDUtMi42NjUtLjMtNS40NjYtMS4zMzItNS40NjYtNS45MyAwLTEuMzEuNDY1LTIuMzggMS4yMzUtMy4yMi0uMTM1LS4zMDMtLjU0LTEuNTIzLjEwNS0zLjE3NiAwIDAgMS4wMDUtLjMyMiAzLjMgMS4yMy45Ni0uMjY3IDEuOTgtLjM5OSAzLS40MDUgMS4wMi4wMDYgMi4wNC4xMzggMyAuNDA1IDIuMjgtMS41NTIgMy4yODUtMS4yMyAzLjI4NS0xLjIzLjY0NSAxLjY1My4yNCAyLjg3My4xMiAzLjE3Ni43NjUuODQgMS4yMyAxLjkxIDEuMjMgMy4yMiAwIDQuNjEtMi44MDUgNS42MjUtNS40NzUgNS45Mi40Mi4zNi44MSAxLjA5Ni44MSAyLjIyIDAgMS42MDYtLjAxNSAyLjg5Ni0uMDE1IDMuMjg2IDAgLjMxNS4yMS42OS44MjUuNTdDMjAuNTY1IDIyLjA5MiAyNCAxNy41OTIgMjQgMTIuMjk3YzAtNi42MjctNS4zNzMtMTItMTItMTIiLz48L3N2Zz4=",
+    "download_url": "https://plugins.releases.mattermost.com/release/mattermost-plugin-github-v2.4.0.tar.gz",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-github/releases/tag/v2.4.0",
+    "hosting": "",
+    "author_type": "mattermost",
+    "release_stage": "production",
+    "enterprise": false,
+    "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmfzpE8ACgkQ0bVLR6XO/sT0rA//VFzgnzf3Cm1mxPuOtNR+3cELm+66GabVZpyMyJrxQew9fg5GfCuT7yVvXUVLkIrGVg8X3IHeI1BBAdsoqIdl+CvQoVSzrFApKA9SKcLDR0+auGNZ0TAAPBPpjIxnxlNNWkf3ewUuN8rqjTin0e/ZCqWjTxmqqi8Xkr6RJ7MSLR9xVtRZ6lNk3QKNJnajmOQwv9I+PX/+okjbUebuhuVnMMkV7rrfFYyxQq2iC6xwYJwYkjhav0VV940Sbw+ua0BFDJuMsn4oKedrxeaTCve+vKcj8OjtrNXvPbdgl7h9nXrvsBHU+o2FshsWAroDnSc9ki1dOPiOd35JZzprfW0NtmFNtokjXe8++if5zWurclh5B6MpgATa8mGpaYQc6C4e0peXKE+THDDFIoaUCqevvr6GtaWgcIpQGytobSrpU8ZmHf2FEArI5Sfb5Excrk8vszufYV2uf3akzOD5pAoke+oTg3q4/07M65Cy7YE+esFNd0Ll/8PIfPz3ZZNtp/HqiB4jJxZqY32lifrftDB3Fv/QGcYLD2cr8jp2OrX8SR7JuXkeh15eLtNzTREGYCXEMhE/eM/tS2m0XSMHx30VKnoOpQlWU3mnCbNGeiwvrF9+EtpHkAUkJX1u0wfDVerUVp8JwK7KNXnjY7WWodXJtvXyVtgemdYTYfpLwJi+DVA=",
+    "repo_name": "mattermost-plugin-github",
+    "manifest": {
+      "id": "github",
+      "name": "GitHub",
+      "description": "GitHub plugin for Mattermost.",
+      "homepage_url": "https://github.com/mattermost/mattermost-plugin-github",
+      "support_url": "https://github.com/mattermost/mattermost-plugin-github/issues",
+      "release_notes_url": "https://github.com/mattermost/mattermost-plugin-github/releases/tag/v2.4.0",
+      "icon_path": "assets/icon.svg",
+      "version": "2.4.0",
+      "min_server_version": "7.1.0",
+      "server": {
+        "executables": {
+          "darwin-amd64": "server/dist/plugin-darwin-amd64",
+          "darwin-arm64": "server/dist/plugin-darwin-arm64",
+          "linux-amd64": "server/dist/plugin-linux-amd64",
+          "linux-arm64": "server/dist/plugin-linux-arm64",
+          "windows-amd64": "server/dist/plugin-windows-amd64.exe"
+        },
+        "executable": ""
+      },
+      "webapp": {
+        "bundle_path": "webapp/dist/main.js"
+      },
+      "settings_schema": {
+        "header": "The GitHub plugin for Mattermost allows users to subscribe to notifications, stay up-to-date with reviews, see the status of pull requests at a glance, and other common GitHub actions - directly from Mattermost. \n \n Instructions for setup are [available here](https://www.mattermost.com/pl/default-github-plugin#configuration).",
+        "footer": "* To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/mattermost/mattermost-plugin-github).",
+        "settings": [
+          {
+            "key": "UsePreregisteredApplication",
+            "display_name": "Use Preregistered OAuth Application:",
+            "type": "bool",
+            "help_text": "Set to false if using GitHub Enterprise. When true, instructs the plugin to use the preregistered GitHub OAuth application - application registration steps can be skipped. Requires [Chimera Proxy](https://github.com/mattermost/chimera) URL to be configured for the server. Cannot be used with GitHub enterprise.",
+            "placeholder": "",
+            "default": false,
+            "hosting": "cloud",
+            "secret": false
+          },
+          {
+            "key": "GitHubOAuthClientID",
+            "display_name": "GitHub OAuth Client ID:",
+            "type": "text",
+            "help_text": "The client ID for the OAuth app registered with GitHub.",
+            "placeholder": "",
+            "default": null,
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "GitHubOAuthClientSecret",
+            "display_name": "GitHub OAuth Client Secret:",
+            "type": "text",
+            "help_text": "The client secret for the OAuth app registered with GitHub.",
+            "placeholder": "",
+            "default": null,
+            "hosting": "",
+            "secret": true
+          },
+          {
+            "key": "WebhookSecret",
+            "display_name": "Webhook Secret:",
+            "type": "generated",
+            "help_text": "The webhook secret set in GitHub.",
+            "placeholder": "",
+            "default": null,
+            "hosting": "",
+            "secret": true
+          },
+          {
+            "key": "EncryptionKey",
+            "display_name": "At Rest Encryption Key:",
+            "type": "generated",
+            "help_text": "The AES encryption key used to encrypt stored access tokens.",
+            "placeholder": "",
+            "default": null,
+            "hosting": "",
+            "secret": true
+          },
+          {
+            "key": "GithubOrg",
+            "display_name": "GitHub Organizations:",
+            "type": "text",
+            "help_text": "(Optional) Set to lock the plugin to one or more GitHub organizations. Provide multiple orgs using a comma-separated list.",
+            "placeholder": "",
+            "default": null,
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "EnterpriseBaseURL",
+            "display_name": "Enterprise Base URL:",
+            "type": "text",
+            "help_text": "(Optional) The base URL for using the plugin with a GitHub Enterprise installation. Example: https://github.example.com",
+            "placeholder": "",
+            "default": null,
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "EnterpriseUploadURL",
+            "display_name": "Enterprise Upload URL:",
+            "type": "text",
+            "help_text": "(Optional) The upload URL for using the plugin with a GitHub Enterprise installation. This is often the same as your Base URL.",
+            "placeholder": "",
+            "default": null,
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "EnableLeftSidebar",
+            "display_name": "Display Notification Counters in Left Sidebar",
+            "type": "bool",
+            "help_text": "When false, the counters showing the user how many open/assigned issues they have in Github will not be shown in the Left Hand Sidebar on desktop browsers.",
+            "placeholder": "",
+            "default": true,
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "EnablePrivateRepo",
+            "display_name": "Enable Private Repositories:",
+            "type": "bool",
+            "help_text": "(Optional) Allow the plugin to work with private repositories. When enabled, existing users must reconnect their accounts to gain access to private repositories. Affected users will be notified by the plugin once private repositories are enabled.",
+            "placeholder": "",
+            "default": null,
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "ConnectToPrivateByDefault",
+            "display_name": "Connect to private Repositories by default:",
+            "type": "bool",
+            "help_text": "(Optional) When enabled, /github connect command will let users connect to their github account and gain access to private repositories without explicitly mentioning private.",
+            "placeholder": "",
+            "default": null,
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "EnableCodePreview",
+            "display_name": "Enable Code Previews:",
+            "type": "dropdown",
+            "help_text": "Allow the plugin to expand permalinks to GitHub files with an actual preview of the linked file.",
+            "placeholder": "",
+            "default": "public",
+            "options": [
+              {
+                "display_name": "Enable for public repositories",
+                "value": "public"
+              },
+              {
+                "display_name": "Enable for public and private repositories. This might leak confidential code into public channels",
+                "value": "privateAndPublic"
+              },
+              {
+                "display_name": "Disable",
+                "value": "disable"
+              }
+            ],
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "EnableWebhookEventLogging",
+            "display_name": "Enable Webhook Event Logging:",
+            "type": "bool",
+            "help_text": "Allow the plugin to log the webhook event. The log level needs to be set to DEBUG.",
+            "placeholder": "",
+            "default": false,
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "ShowAuthorInCommitNotification",
+            "display_name": "Show Author in commit notification:",
+            "type": "bool",
+            "help_text": "In 'Pushes' event notification, show commit author instead of commit committer.",
+            "placeholder": "",
+            "default": false,
+            "hosting": "",
+            "secret": false
+          }
+        ],
+        "sections": null
+      }
+    },
+    "platforms": {
+      "linux-amd64": {
+        "download_url": "https://plugins.releases.mattermost.com/release/mattermost-plugin-github-v2.4.0-linux-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmfzpE8ACgkQ0bVLR6XO/sSDtQ//XkFqxEvhGjna49of+s3NvYa415ekeDZBAabpW9IJPoUqO9ymp5g5ktAHujYpi+n2gLIfegaH5dVlrrFYSSnUxG4L8skKcM/yL/1rK/ND5gXo7VVB0KlYvc/M4i9skLCbeBoqbctsejzOAeYw2Y8qSI6HPF9cqu8FpJRGq0CJ+k5L5/f0SXB0IbPlQU4P8cVlCpnHHowfsmFCNQazLiCTX11hnrZMmBX/DQBmOORN4bnqqD4hPHCRA/F47y8H/NYx/RcD1cY1JLaF86cBQTEv7dXoFLlGSCjnrVLa3YGXGGNpRLhyrBp3WujosH9i8Tndn9CctmFlciWuO+wcTBYYeXD2dy0Z2+n09He9oZxzw9yuL+sxDr/8CONNJwGv3swBXPc4/niNjzDUBorKetqVbfrcB6moGn+d0vPVJL1qkpED6bujYuYVWNnKGVu19hBqD+AJeYygCPrcx67FndqUTD65/xuYv015XPdEdZDdJ8y3gXh6EC/YVfPcMZcS/INdjAX+hGCEGMEw2VDtW671ynYVXKAk7r3p9t+hEDvkywfK4lgL59AO8BpJOMQvYLOIljLnoTu5/Q3qfUZFclLM4qSIb/g/nh84QvKW3jZNSl7Hu3xIDgKWHqD1H02yEuon8jnO5JYHEZTJ246wmWMYdvpE1QtQ4nDQiXU0dDWPOHI="
+      },
+      "darwin-amd64": {},
+      "windows-amd64": {
+        "download_url": "https://plugins.releases.mattermost.com/release/mattermost-plugin-github-v2.4.0-windows-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmfzpE8ACgkQ0bVLR6XO/sTnyQ//akKkA/OUKpy468NQ5RkAmHIW/f9x9Dwo6dyuikOSvI3bjhaV54rxqlT/xnVL2I9Qaqo/TLA59DIem4HAyba/KjAb+de9OrQ6YSxdX9BUCAJ2sGQCFDnnjE9MiImY4NmkuE6RjWjt9qqGYyUzWoSSLk7lU82S3yPmX1ucO3gEMQpsO9fEr+RknLp5tATROY2iKh9V/iasxCWCr760qT26yV6BOKDus2T7ZfuGmfQ4CD5emNeAhvqcr9UXvvL0L+f+sekj9hga5S9v0/YObeUot/AInUJpGueMJkM+btha6rtxnolDNiFGezUEQ3iqUoLn9kMDA76vx0/5JWQaM1+Bh3JF84S7km1EOvCVZQjIusB1zWAnffgtlPxPUx4nOkF9S/SxQguY+rhhf1hNvsdcufseB4BAAv34FkJq/2b2QSoDztTD5CKru1cc0UFLTPXeBEzWP7l4JNJ8SmeJK1GepYG/isKt1fazxzStAtMRuhcEJt2zEW+dNFrW67zKrvCqv5DdUSrS6YidGg0HQO0/c3+nv2Wb5X7vzmwUazKXFhit5blDI3MAbfel0QC0YMpO8PwRlQJogD1M6r6Ils4bQEn6GEIDPmWaGm0UJ6e9KD9VC0i2Pj+Q5l8sFi8paH7bL7/sB1m7Gss9rsz+xJkhZB+v8GD7Wt7usKjoFzzxfvc="
+      }
+    },
+    "updated_at": "2025-04-08T10:52:24.554118775Z"
+  },
+  {
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-github",
+    "icon_data": "data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+R2l0SHViIGljb248L3RpdGxlPjxwYXRoIGQ9Ik0xMiAuMjk3Yy02LjYzIDAtMTIgNS4zNzMtMTIgMTIgMCA1LjMwMyAzLjQzOCA5LjggOC4yMDUgMTEuMzg1LjYuMTEzLjgyLS4yNTguODItLjU3NyAwLS4yODUtLjAxLTEuMDQtLjAxNS0yLjA0LTMuMzM4LjcyNC00LjA0Mi0xLjYxLTQuMDQyLTEuNjFDNC40MjIgMTguMDcgMy42MzMgMTcuNyAzLjYzMyAxNy43Yy0xLjA4Ny0uNzQ0LjA4NC0uNzI5LjA4NC0uNzI5IDEuMjA1LjA4NCAxLjgzOCAxLjIzNiAxLjgzOCAxLjIzNiAxLjA3IDEuODM1IDIuODA5IDEuMzA1IDMuNDk1Ljk5OC4xMDgtLjc3Ni40MTctMS4zMDUuNzYtMS42MDUtMi42NjUtLjMtNS40NjYtMS4zMzItNS40NjYtNS45MyAwLTEuMzEuNDY1LTIuMzggMS4yMzUtMy4yMi0uMTM1LS4zMDMtLjU0LTEuNTIzLjEwNS0zLjE3NiAwIDAgMS4wMDUtLjMyMiAzLjMgMS4yMy45Ni0uMjY3IDEuOTgtLjM5OSAzLS40MDUgMS4wMi4wMDYgMi4wNC4xMzggMyAuNDA1IDIuMjgtMS41NTIgMy4yODUtMS4yMyAzLjI4NS0xLjIzLjY0NSAxLjY1My4yNCAyLjg3My4xMiAzLjE3Ni43NjUuODQgMS4yMyAxLjkxIDEuMjMgMy4yMiAwIDQuNjEtMi44MDUgNS42MjUtNS40NzUgNS45Mi40Mi4zNi44MSAxLjA5Ni44MSAyLjIyIDAgMS42MDYtLjAxNSAyLjg5Ni0uMDE1IDMuMjg2IDAgLjMxNS4yMS42OS44MjUuNTdDMjAuNTY1IDIyLjA5MiAyNCAxNy41OTIgMjQgMTIuMjk3YzAtNi42MjctNS4zNzMtMTItMTItMTIiLz48L3N2Zz4=",
     "download_url": "https://plugins-store.test.mattermost.com/release/mattermost-plugin-github-v2.3.0.tar.gz",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-githubreleases/tag/v2.3.0",
     "hosting": "",


### PR DESCRIPTION
#### Summary
This PR upgrades the [github plugin](https://github.com/mattermost/mattermost-plugin-github) to version [2.4.0](https://github.com/mattermost/mattermost-plugin-github/releases/tag/v2.4.0).