### PR TITLE
Add v4.3.0 of mattermost-plugin-jira to the marketplace

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -33359,6 +33359,200 @@
   {
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-jira",
     "icon_data": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgNzMuMjcgNzUuNzYiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDojMjY4NGZmO30uY2xzLTJ7ZmlsbDp1cmwoI2xpbmVhci1ncmFkaWVudCk7fS5jbHMtM3tmaWxsOnVybCgjbGluZWFyLWdyYWRpZW50LTIpO308L3N0eWxlPjxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50IiB4MT0iMzQuNjQiIHkxPSIxNS4zNSIgeDI9IjE5IiB5Mj0iMzAuOTkiIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj48c3RvcCBvZmZzZXQ9IjAuMTgiIHN0b3AtY29sb3I9IiMwMDUyY2MiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMyNjg0ZmYiLz48L2xpbmVhckdyYWRpZW50PjxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50LTIiIHgxPSIzOC43OCIgeTE9IjYwLjI4IiB4Mj0iNTQuMzkiIHkyPSI0NC42NyIgeGxpbms6aHJlZj0iI2xpbmVhci1ncmFkaWVudCIvPjwvZGVmcz48dGl0bGU+SmlyYSBTb2Z0d2FyZS1pY29uLWJsdWU8L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJCbHVlIj48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik03Mi40LDM1Ljc2LDM5LjgsMy4xNiwzNi42NCwwaDBMMTIuMSwyNC41NGgwTC44OCwzNS43NkEzLDMsMCwwLDAsLjg4LDQwTDIzLjMsNjIuNDIsMzYuNjQsNzUuNzYsNjEuMTgsNTEuMjJsLjM4LS4zOEw3Mi40LDQwQTMsMywwLDAsMCw3Mi40LDM1Ljc2Wk0zNi42NCw0OS4wOGwtMTEuMi0xMS4yLDExLjItMTEuMiwxMS4yLDExLjJaIi8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMzYuNjQsMjYuNjhBMTguODYsMTguODYsMCwwLDEsMzYuNTYuMDlMMTIuMDUsMjQuNTksMjUuMzksMzcuOTMsMzYuNjQsMjYuNjhaIi8+PHBhdGggY2xhc3M9ImNscy0zIiBkPSJNNDcuODcsMzcuODUsMzYuNjQsNDkuMDhhMTguODYsMTguODYsMCwwLDEsMCwyNi42OGgwTDYxLjIxLDUxLjE5WiIvPjwvZz48L2c+PC9zdmc+",
+    "download_url": "https://plugins.releases.mattermost.com/release/mattermost-plugin-jira-v4.3.0.tar.gz",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-jira/releases/tag/v4.3.0",
+    "hosting": "",
+    "author_type": "mattermost",
+    "release_stage": "production",
+    "enterprise": false,
+    "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmgrJ3kACgkQ0bVLR6XO/sSvmA//dniUxDDPD+vsFlH+E6dQawHxtOdMkmKKZAl+VoDByUTjY0YpgJS7CRvZ5yGb9dFcryEPH4F2qt5/hPaZi8W0/qq03tHcjjtnoxagS7PvTyaUcGtVK6SfALAUCEf6wmtjh5FEBBvssNbb0geA7t0rye0fsHrqGM1A5SIQ6HQg+KeLpobASUxjE26P2CxIJFREaNz612LXmzkkP1yCKMTg1byrb41IFV17ddVUZB/qJZNqRljEmPIavec0E3Z1pUW1rpidBLAz9ZyWM/rjYTVpfrBN6rLx5SSJ7PFYI5iQGR0ut2ktBXSAms4rCdeHYDidJP4GdJh1AXrz9GdNRyAYpWLUr660vGdn5/BdXQZ5VTIenCaLddcl6gZiru0muhq6/ImafU5NcvMxQmi3Blqrx9iSz/of95wm4khdSIRiZgpdSo9GMMGvnDGH2Xm4vgG5DGbj9YsdPdideTimwgBuZr+UnxdXmQHbQKStxpxxPgjN0Ei0OGIeWXuZm4lyMOdye6lC44aq2C/9SBkDBwakRssu1B3AwOeWzNHp5dVDazF9QaPSCV6MYQgTA7SGn60kIfw3Uv/pRww7hdwLGPiN4JpePd1xJnZfXnB8Kqo7ZniEnrCPnHxXJFKb1gLdJT0r1SVOAMBd08Q3dM/XkJltsYMRCi4qAXHiHOoEuxbrr8A=",
+    "repo_name": "mattermost-plugin-jira",
+    "manifest": {
+      "id": "jira",
+      "name": "Jira",
+      "description": "Atlassian Jira plugin for Mattermost.",
+      "homepage_url": "https://github.com/mattermost/mattermost-plugin-jira",
+      "support_url": "https://github.com/mattermost/mattermost-plugin-jira/issues",
+      "release_notes_url": "https://github.com/mattermost/mattermost-plugin-jira/releases/tag/v4.3.0",
+      "icon_path": "assets/icon.svg",
+      "version": "4.3.0",
+      "min_server_version": "7.8.0",
+      "server": {
+        "executables": {
+          "darwin-amd64": "server/dist/plugin-darwin-amd64",
+          "darwin-arm64": "server/dist/plugin-darwin-arm64",
+          "linux-amd64": "server/dist/plugin-linux-amd64",
+          "linux-arm64": "server/dist/plugin-linux-arm64",
+          "windows-amd64": "server/dist/plugin-windows-amd64.exe"
+        },
+        "executable": ""
+      },
+      "webapp": {
+        "bundle_path": "webapp/dist/main.js"
+      },
+      "settings_schema": {
+        "header": "Please refer to the '/jira' command [**documentation**](https://mattermost.com/pl/integrate/jira-admin-setup) to further configure the Jira plugin.",
+        "footer": "Please refer to the '/jira' command [**documentation**](https://mattermost.com/pl/integrate/jira-admin-setup) to further configure the Jira plugin. Specifically, ['/jira instance [un-]install'](https://mattermost.com/pl/integrate/jira-admin-setup) and ['/jira webhook'](https://mattermost.com/pl/integrate/configure-webhooks-in-jira).",
+        "settings": [
+          {
+            "key": "EnableJiraUI",
+            "display_name": "Allow users to attach and create Jira issues in Mattermost:",
+            "type": "bool",
+            "help_text": "When **false**, users cannot attach and create Jira issues in Mattermost. Does not affect Jira webhook notifications. Select **false** then disable and re-enable this plugin in **System Console > Plugins > Plugin Management** to reset the plugin state for all users. \n \n When **true**, install this plugin to your Jira instance with '/jira install' to allow users to create and manage issues across Mattermost channels. See [documentation](https://about.mattermost.com/default-jira-plugin-link-application) to learn more.",
+            "placeholder": "",
+            "default": true,
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "secret",
+            "display_name": "Webhook Secret:",
+            "type": "generated",
+            "help_text": "The secret used to authenticate the webhook to Mattermost.",
+            "regenerate_help_text": "Regenerates the secret for the webhook URL endpoint. Regenerating the secret invalidates your existing Jira integrations.",
+            "placeholder": "",
+            "default": null,
+            "hosting": "",
+            "secret": true
+          },
+          {
+            "key": "RolesAllowedToEditJiraSubscriptions",
+            "display_name": "Mattermost Roles Allowed to Edit Jira Subscriptions:",
+            "type": "radio",
+            "help_text": "Mattermost users who can subscribe channels to Jira tickets.",
+            "placeholder": "",
+            "default": "system_admin",
+            "options": [
+              {
+                "display_name": "All users",
+                "value": "users"
+              },
+              {
+                "display_name": "Users who can manage channel settings",
+                "value": "channel_admin"
+              },
+              {
+                "display_name": "Users who can manage teams",
+                "value": "team_admin"
+              },
+              {
+                "display_name": "System Admins",
+                "value": "system_admin"
+              }
+            ],
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "GroupsAllowedToEditJiraSubscriptions",
+            "display_name": "Jira Groups Allowed to Edit Jira Subscriptions:",
+            "type": "text",
+            "help_text": "Comma separated list of Group Names. List the Jira user groups who can create subscriptions. If none are specified, any Jira user can create a subscription. Jira groups restrictions are only applicable for a legacy instance installed on Jira 2.4 or earlier.",
+            "placeholder": "",
+            "default": "",
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "SecurityLevelEmptyForJiraSubscriptions",
+            "display_name": "Default Subscription Security Level to Empty:",
+            "type": "bool",
+            "help_text": "Subscriptions will only include issues that have a security level assigned if the appropriate security level has been included as a filter",
+            "placeholder": "",
+            "default": true,
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "JiraAdminAdditionalHelpText",
+            "display_name": "Additional Help Text to be shown with Jira Help:",
+            "type": "text",
+            "help_text": "Additional Help Text to be shown to the user along with the output of '/jira help' command.",
+            "placeholder": "",
+            "default": "",
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "HideDecriptionComment",
+            "display_name": "Hide issue descriptions and comments:",
+            "type": "bool",
+            "help_text": "Hide detailed issue descriptions and comments from Subscription and Webhook messages",
+            "placeholder": "",
+            "default": false,
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "EnableAutocomplete",
+            "display_name": "Enable slash command autocomplete:",
+            "type": "bool",
+            "help_text": "Autocomplete guides users through the available '/jira' slash commands.",
+            "placeholder": "",
+            "default": true,
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "DisplaySubscriptionNameInNotifications",
+            "display_name": "Display subscription name in notifications:",
+            "type": "bool",
+            "help_text": "Display subscription name in post when a subscription posts to a channel",
+            "placeholder": "",
+            "default": false,
+            "hosting": "",
+            "secret": false
+          },
+          {
+            "key": "EncryptionKey",
+            "display_name": "At Rest Encryption Key:",
+            "type": "generated",
+            "help_text": "The encryption key used to encrypt stored API tokens.",
+            "placeholder": "",
+            "default": null,
+            "hosting": "",
+            "secret": true
+          },
+          {
+            "key": "AdminAPIToken",
+            "display_name": "Admin API Token",
+            "type": "text",
+            "help_text": "Set this [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/) to get notified for comment and issue created events when the user triggering the event is not connected to Jira. This is also used for setting up autolink in the plugin.\n **Note:** API token should be created using an admin Jira account. Otherwise, the notification will not be delivered for projects that the user cannot access and autolink will not work.",
+            "placeholder": "",
+            "default": "",
+            "hosting": "",
+            "secret": true
+          },
+          {
+            "key": "AdminEmail",
+            "display_name": "Admin Email",
+            "type": "text",
+            "help_text": "**Note** Admin email is necessary to setup autolink for the Jira plugin and to to get notified for comment and issue created events when the user triggering the event is not connected to Jira",
+            "placeholder": "",
+            "default": "",
+            "hosting": "",
+            "secret": false
+          }
+        ],
+        "sections": null
+      }
+    },
+    "platforms": {
+      "linux-amd64": {
+        "download_url": "https://plugins.releases.mattermost.com/release/mattermost-plugin-jira-v4.3.0-linux-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmgrJ3gACgkQ0bVLR6XO/sRa8Q/8Ck9pI3gqtdq7KCo8NWhOP2PEvpHCwqiVPii+uGUbs9qKXXZ5oR94pgiR7Q7vjjhEUeWWQiUgxN2+rfXYjOM25Nyy9g/L/5K+4Y9d/sPUjQpwafS0qQQxiupdnsTZwwn3GkrOToyE5LQNUpX+kmKd4lbZsvxqCtnJr//jNwcarG0cl6sXQLSmym9Q52lBQ6wMzC/2FstzZvgwIs0P0RQxGxBVZlXtA4kiqrza3tZvfZBiws53nothXwg1ylVu5+UHsQZ14TgT+4BL18zx/1u1HB6enJXVjuscMEqJLvcUW3qpeUEV6ZZzhV8wHlxQ9JHSCS0HA/v7/67VUM+ksVmlPUGG0/vRTaMLdJ29NW/Zz3MkTS7i3U0hc9g3KjhXQcqgppjOTEZmAgE+CQWguhcSP6WSGiYEA/Q70Sfhj4DwKtLdJfaaybtvHZMzSxNBGgXSeOEAYJYjKzqrU6UpiEXwBstIxnQspdMVGWpAKoxwQs1QRPrA0HTe31db7plXG+XbHY3mgKhPxHJ53pNMTb2+wq56XwLUlNxXupxAL1kZOmIaF5CjVGy1/634hFebhu27AhMYfvkdHHAlgw9x0yQiADBRZsr41FXZ/0YgOM0vB7481mrpFORi8jhv4hf9NypLEi6Nf8N4F5vdN5/g/MWqgAUy2tNUbNHCEOJUq/msvR0="
+      },
+      "darwin-amd64": {},
+      "windows-amd64": {
+        "download_url": "https://plugins.releases.mattermost.com/release/mattermost-plugin-jira-v4.3.0-windows-amd64.tar.gz",
+        "signature": "iQIzBAABCAAdFiEExViBuA9p6GO4WtXR0bVLR6XO/sQFAmgrJ3kACgkQ0bVLR6XO/sTbgA//fQgNpL2LPfP7/HWpHYEQrJZQ4B1qXvahZjgUEsVTN43B32em0F4l8JnmBvW6kTF996OcNOO58wNrTFf47+RIQWKL8TKtVmEjN7JSjucN7b+Mz3cektlR3oEbguxOKB5pf8UEb+98ZWeakeVGttqMdhLNxQDxum29p++w3mBWGQo8lL6W2vKI7j0QUqJmF/wf7uMsfFaaXyOPGD6sOm9hi7+EcS1mYyWoIOS34xrwKaSXWRWPhlgD0iCUAQH0Spgiz8/qz+L+e1VBBKa50XRtSmcQU20+yC7CBIer/LDviQjximkteG8Zb2vCL/axCSF1+goraCbkr+NNEntIz2619au6tWgcsl/B8IZCqFTWaqs9i+WmPb0JTiAjAOuMaEbJIyJSY/LlJ7hLPkZXCreje87w4G5iTUaGAna6r9oVRgfmUrvwxHD814/72V+23tzYEg3GaXl1DXB0B9V4gRwpvIFo6tTahExYWqPbzDWtWpex/h1vngYyc6x8e0Jgbvh3c0sv9SQ1PfQ8AAFDkcZ8KUaQj9zWBdY9jIPnBxboxtpq+IxDZEPnDCPPYuP89AIdcONQrGwxnx82SPfgAaRuoijtM/ZPadPmK/wBsSH7gVpPFXXIFt9lmyex5AcInTY0yc6ZgSs3KyKhyTttKsuWx/cXrU1witEy88iE/KxmSEU="
+      }
+    },
+    "updated_at": "2025-05-27T10:03:21.179678469Z"
+  },
+  {
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-jira",
+    "icon_data": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgNzMuMjcgNzUuNzYiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDojMjY4NGZmO30uY2xzLTJ7ZmlsbDp1cmwoI2xpbmVhci1ncmFkaWVudCk7fS5jbHMtM3tmaWxsOnVybCgjbGluZWFyLWdyYWRpZW50LTIpO308L3N0eWxlPjxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50IiB4MT0iMzQuNjQiIHkxPSIxNS4zNSIgeDI9IjE5IiB5Mj0iMzAuOTkiIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj48c3RvcCBvZmZzZXQ9IjAuMTgiIHN0b3AtY29sb3I9IiMwMDUyY2MiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMyNjg0ZmYiLz48L2xpbmVhckdyYWRpZW50PjxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50LTIiIHgxPSIzOC43OCIgeTE9IjYwLjI4IiB4Mj0iNTQuMzkiIHkyPSI0NC42NyIgeGxpbms6aHJlZj0iI2xpbmVhci1ncmFkaWVudCIvPjwvZGVmcz48dGl0bGU+SmlyYSBTb2Z0d2FyZS1pY29uLWJsdWU8L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJCbHVlIj48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik03Mi40LDM1Ljc2LDM5LjgsMy4xNiwzNi42NCwwaDBMMTIuMSwyNC41NGgwTC44OCwzNS43NkEzLDMsMCwwLDAsLjg4LDQwTDIzLjMsNjIuNDIsMzYuNjQsNzUuNzYsNjEuMTgsNTEuMjJsLjM4LS4zOEw3Mi40LDQwQTMsMywwLDAsMCw3Mi40LDM1Ljc2Wk0zNi42NCw0OS4wOGwtMTEuMi0xMS4yLDExLjItMTEuMiwxMS4yLDExLjJaIi8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMzYuNjQsMjYuNjhBMTguODYsMTguODYsMCwwLDEsMzYuNTYuMDlMMTIuMDUsMjQuNTksMjUuMzksMzcuOTMsMzYuNjQsMjYuNjhaIi8+PHBhdGggY2xhc3M9ImNscy0zIiBkPSJNNDcuODcsMzcuODUsMzYuNjQsNDkuMDhhMTguODYsMTguODYsMCwwLDEsMCwyNi42OGgwTDYxLjIxLDUxLjE5WiIvPjwvZz48L2c+PC9zdmc+",
     "download_url": "https://plugins.releases.mattermost.com/release/mattermost-plugin-jira-v4.2.1.tar.gz",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-jira/releases/tag/v4.2.1",
     "hosting": "",


### PR DESCRIPTION
#### Summary
This PR upgrades the [jira plugin](https://github.com/mattermost/mattermost-plugin-jira) to version [4.3.0](https://github.com/mattermost/mattermost-plugin-jira/releases/tag/v4.3.0).