### PR TITLE
MM-68118 Fixing flakiness and issues with adding new plugin versions

### DIFF
--- a/cmd/generator/add.go
+++ b/cmd/generator/add.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/blang/semver"
@@ -110,6 +111,10 @@ var addCmd = &cobra.Command{
 
 		if _, err = semver.ParseTolerant(tag); err != nil {
 			return errors.Wrapf(err, "%v is an invalid tag. Something like v2.3.4 is expected", tag)
+		}
+
+		if !strings.HasPrefix(tag, "v") {
+			tag = "v" + tag
 		}
 
 		pluginHost, err := command.Flags().GetString("remote-plugin-store")

--- a/cmd/generator/add.go
+++ b/cmd/generator/add.go
@@ -27,6 +27,7 @@ func init() {
 	addCmd.Flags().Bool("enterprise", false, "Mark this plugin as only available to installations with an E20-only plugins license")
 	addCmd.Flags().Bool("cloud", false, "Mark this plugin as only available to cloud installations")
 	addCmd.Flags().Bool("on-prem", false, "Mark this plugin as only available to on-prem installations")
+	addCmd.Flags().String("github-org", defaultGitHubOrg, "GitHub organization for fallback URLs when manifest fields are empty.")
 }
 
 var addCmd = &cobra.Command{
@@ -116,10 +117,16 @@ var addCmd = &cobra.Command{
 			return err
 		}
 
-		bundleURL := fmt.Sprintf("%s/%s-%s.tar.gz", pluginHost, repo, tag)
-		signatureURL := bundleURL + ".sig"
+		githubOrg, err := command.Flags().GetString("github-org")
+		if err != nil {
+			return err
+		}
 
-		bundleData, err := downloadBundleData(bundleURL)
+		// Use the user-provided tag to fetch the bundle; the canonical URL stored in
+		// the database is rebuilt from manifest.Version below to match CDN naming.
+		fetchURL := fmt.Sprintf("%s/%s-%s.tar.gz", pluginHost, repo, tag)
+
+		bundleData, err := downloadBundleData(fetchURL)
 		if err != nil {
 			return errors.Wrapf(err, "failed downloading bundle data")
 		}
@@ -149,21 +156,47 @@ var addCmd = &cobra.Command{
 			if err != nil {
 				return errors.Wrap(err, "failed to get icon")
 			}
+		} else {
+			logger.WithFields(logrus.Fields{
+				"repo": repo,
+				"tag":  tag,
+			}).Warn("Plugin manifest has no icon_path. Consider adding an icon to the plugin.")
 		}
+
+		bundleURL := fmt.Sprintf("%s/%s-v%s.tar.gz", pluginHost, repo, manifest.Version)
+		signatureURL := bundleURL + ".sig"
 
 		signature, err := downloadSignature(signatureURL)
 		if err != nil {
 			return errors.Wrap(err, "failed to download plugin signature")
 		}
 
+		homepageURL := manifest.HomepageURL
+		if homepageURL == "" {
+			homepageURL = fmt.Sprintf("https://github.com/%s/%s", githubOrg, repo)
+			logger.WithFields(logrus.Fields{
+				"repo":         repo,
+				"homepage_url": homepageURL,
+			}).Info("Manifest has no homepage_url, using fallback")
+		}
+
+		releaseNotesURL := manifest.ReleaseNotesURL
+		if releaseNotesURL == "" {
+			releaseNotesURL = fmt.Sprintf("https://github.com/%s/%s/releases/tag/v%s", githubOrg, repo, manifest.Version)
+			logger.WithFields(logrus.Fields{
+				"repo":              repo,
+				"release_notes_url": releaseNotesURL,
+			}).Info("Manifest has no release_notes_url, using fallback")
+		}
+
 		labels := []model.Label{}
 
 		plugin := &model.Plugin{
 			RepoName:        repo,
-			HomepageURL:     manifest.HomepageURL,
+			HomepageURL:     homepageURL,
 			IconData:        iconData,
 			DownloadURL:     bundleURL,
-			ReleaseNotesURL: manifest.ReleaseNotesURL,
+			ReleaseNotesURL: releaseNotesURL,
 			Labels:          labels,
 			Signature:       signature,
 			Manifest:        &manifest,

--- a/cmd/generator/bundles.go
+++ b/cmd/generator/bundles.go
@@ -167,7 +167,11 @@ func checkIfRemoteBundlesExist(remotePluginHost, pluginWithVersion string) ([]st
 		}
 	}
 
-	if darwin := checkDarwinBundle(remotePluginHost, pluginWithVersion); darwin != "" {
+	darwin, err := checkDarwinBundle(remotePluginHost, pluginWithVersion)
+	if err != nil {
+		return nil, err
+	}
+	if darwin != "" {
 		result = append(result, darwin)
 	}
 
@@ -177,19 +181,18 @@ func checkIfRemoteBundlesExist(remotePluginHost, pluginWithVersion string) ([]st
 // checkDarwinBundle returns the first darwin bundle naming convention with both
 // a bundle and signature available, preferring "darwin-amd64" over "osx-amd64".
 // Returns an empty string if neither variant exists.
-func checkDarwinBundle(remotePluginHost, pluginWithVersion string) string {
+func checkDarwinBundle(remotePluginHost, pluginWithVersion string) (string, error) {
 	for _, platform := range []string{DarwinAmd64, OsxAmd64} {
 		exists, err := remoteBundleExists(remotePluginHost, pluginWithVersion, platform)
 		if err != nil {
-			logger.Debugf("Error checking darwin bundle %s: %v", platform, err)
-			continue
+			return "", err
 		}
 		if exists {
-			return platform
+			return platform, nil
 		}
 	}
 
-	return ""
+	return "", nil
 }
 
 // remoteBundleExists reports whether both a platform-specific bundle and its signature

--- a/cmd/generator/bundles.go
+++ b/cmd/generator/bundles.go
@@ -13,8 +13,11 @@ import (
 	"github.com/mattermost/mattermost-marketplace/internal/model"
 )
 
-// OSX-specific bundle URLs are stored in the plugin store as `osx` rather than `darwin`
-const OsxAmd64 = "osx-amd64"
+// Older plugins publish darwin bundles as "osx-amd64"; newer ones use "darwin-amd64".
+const (
+	OsxAmd64    = "osx-amd64"
+	DarwinAmd64 = "darwin-amd64"
+)
 
 func init() {
 	generatorCmd.AddCommand(migrateCmd)
@@ -122,6 +125,10 @@ func addPlatformSpecificBundles(plugin *model.Plugin, pluginHost string) (*model
 		}
 		defer res.Body.Close()
 
+		if res.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("received %d status code downloading signature from %s", res.StatusCode, sigPath)
+		}
+
 		signatureBytes, err := io.ReadAll(res.Body)
 		if err != nil {
 			return nil, err
@@ -136,7 +143,7 @@ func addPlatformSpecificBundles(plugin *model.Plugin, pluginHost string) (*model
 		switch platform {
 		case model.LinuxAmd64:
 			plugin.Platforms.LinuxAmd64 = bundle
-		case OsxAmd64:
+		case OsxAmd64, DarwinAmd64:
 			plugin.Platforms.DarwinAmd64 = bundle
 		case model.WindowsAmd64:
 			plugin.Platforms.WindowsAmd64 = bundle
@@ -150,33 +157,75 @@ func addPlatformSpecificBundles(plugin *model.Plugin, pluginHost string) (*model
 func checkIfRemoteBundlesExist(remotePluginHost, pluginWithVersion string) ([]string, error) {
 	result := []string{}
 
-	platforms := []string{model.LinuxAmd64, OsxAmd64, model.WindowsAmd64}
-	for _, platform := range platforms {
-		path := fmt.Sprintf("%s/%s-%s.tar.gz", remotePluginHost, pluginWithVersion, platform)
-
-		// Check if plugin bundle exists on remote file server
-		res, err := http.Head(path)
+	for _, platform := range []string{model.LinuxAmd64, model.WindowsAmd64} {
+		exists, err := remoteBundleExists(remotePluginHost, pluginWithVersion, platform)
 		if err != nil {
 			return nil, err
 		}
-		if res.StatusCode != http.StatusOK {
-			logger.Debugf("Platform-specific bundle not found %s %s", pluginWithVersion, path)
-			continue
+		if exists {
+			result = append(result, platform)
 		}
+	}
 
-		// Check if signature exists on remote file server
-		sigPath := path + ".sig"
-		res, err = http.Head(sigPath)
-		if err != nil {
-			return nil, err
-		}
-		if res.StatusCode != http.StatusOK {
-			logger.Debugf("Platform-specific bundle signature not found %s %s", pluginWithVersion, sigPath)
-			continue
-		}
-
-		result = append(result, platform)
+	if darwin := checkDarwinBundle(remotePluginHost, pluginWithVersion); darwin != "" {
+		result = append(result, darwin)
 	}
 
 	return result, nil
+}
+
+// checkDarwinBundle returns the first darwin bundle naming convention with both
+// a bundle and signature available, preferring "darwin-amd64" over "osx-amd64".
+// Returns an empty string if neither variant exists.
+func checkDarwinBundle(remotePluginHost, pluginWithVersion string) string {
+	for _, platform := range []string{DarwinAmd64, OsxAmd64} {
+		exists, err := remoteBundleExists(remotePluginHost, pluginWithVersion, platform)
+		if err != nil {
+			logger.Debugf("Error checking darwin bundle %s: %v", platform, err)
+			continue
+		}
+		if exists {
+			return platform
+		}
+	}
+
+	return ""
+}
+
+// remoteBundleExists reports whether both a platform-specific bundle and its signature
+// are available on the remote file server.
+func remoteBundleExists(remotePluginHost, pluginWithVersion, platform string) (bool, error) {
+	bundlePath := fmt.Sprintf("%s/%s-%s.tar.gz", remotePluginHost, pluginWithVersion, platform)
+
+	ok, err := remoteResourceExists(bundlePath)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		logger.Debugf("Platform-specific bundle not found %s %s", pluginWithVersion, bundlePath)
+		return false, nil
+	}
+
+	sigPath := bundlePath + ".sig"
+	ok, err = remoteResourceExists(sigPath)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		logger.Debugf("Platform-specific bundle signature not found %s %s", pluginWithVersion, sigPath)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// remoteResourceExists issues a HEAD request, returning true on a 200 response.
+func remoteResourceExists(url string) (bool, error) {
+	res, err := http.Head(url)
+	if err != nil {
+		return false, err
+	}
+	defer res.Body.Close()
+
+	return res.StatusCode == http.StatusOK, nil
 }

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -532,7 +532,7 @@ func pluginsToDatabase(path string, plugins []*model.Plugin) error {
 		},
 	)
 
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open existing database %s", path)
 	}

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -96,20 +96,11 @@ var generatorCmd = &cobra.Command{
 
 		ctx := context.Background()
 
-		repositoryNames := []string{
-			"mattermost-plugin-github",
-			"mattermost-plugin-autolink",
-			"mattermost-plugin-zoom",
-			"mattermost-plugin-jira",
-			"mattermost-plugin-welcomebot",
-			"mattermost-plugin-jenkins",
-			"mattermost-plugin-antivirus",
-			"mattermost-plugin-custom-attributes",
-			"mattermost-plugin-aws-SNS",
-			"mattermost-plugin-gitlab",
-			"mattermost-plugin-nps",
-			"mattermost-plugin-webex",
+		repositoryNames, err := getPluginRepositoryNames(ctx, client, githubOrg)
+		if err != nil {
+			return errors.Wrap(err, "failed to discover plugin repositories")
 		}
+		logger.Infof("discovered %d plugin repositories in %s", len(repositoryNames), githubOrg)
 
 		plugins := []*model.Plugin{}
 
@@ -149,6 +140,39 @@ var generatorCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+// getPluginRepositoryNames discovers all mattermost-plugin-* repositories in the given GitHub org.
+func getPluginRepositoryNames(ctx context.Context, client *github.Client, org string) ([]string, error) {
+	var names []string
+
+	opts := &github.RepositoryListByOrgOptions{
+		Type: "public",
+		ListOptions: github.ListOptions{
+			PerPage: 100,
+		},
+	}
+
+	for {
+		repos, resp, err := client.Repositories.ListByOrg(ctx, org, opts)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to list repositories for org %s", org)
+		}
+
+		for _, repo := range repos {
+			name := repo.GetName()
+			if strings.HasPrefix(name, "mattermost-plugin-") && !repo.GetArchived() {
+				names = append(names, name)
+			}
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return names, nil
 }
 
 // getReleasePlugins queries GitHub for all releases of the given plugin, sorting by plugin version descending.
@@ -508,16 +532,11 @@ func pluginsToDatabase(path string, plugins []*model.Plugin) error {
 		},
 	)
 
-	file, err := os.OpenFile(path, os.O_RDWR, 0644)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_TRUNC, 0644)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open existing database %s", path)
 	}
 	defer file.Close()
-
-	_, err = file.Seek(0, 0)
-	if err != nil {
-		return err
-	}
 
 	err = model.PluginsToWriter(file, plugins)
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR fixes a few issues we've been having when releasing new versions:
- Automatically filling out the `darwin-amd64` with a base64 signature added to it
- Flakiness with some `release_notes_url` and `download_url` values coming out wrong
- Replacing the hardcoded list of plugin repos in the main file with a script that discovers them automatically (from what I could see this isn't in use in the `generator add` command, but I thought this was technical debt worth paying just in case)

Let me know if there's anything else in the marketplace we may want to fix in this PR :)

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-68118
